### PR TITLE
Flow Router fixes/optimizations

### DIFF
--- a/react-todos/client/routes.jsx
+++ b/react-todos/client/routes.jsx
@@ -1,10 +1,9 @@
 // This data is used on every page; also we want to make sure we route to the
 // first list instead of no list at all
-var handles = [
-  Meteor.subscribe("publicLists"),
-  Meteor.subscribe("privateLists")
-];
-var subsReady;
+FlowRouter.subscriptions = function () {
+  this.register('publicLists', Meteor.subscribe('publicLists'));
+  this.register('privateLists', Meteor.subscribe('privateLists'));
+};
 
 FlowRouter.route("/", {
   name: "root",
@@ -28,13 +27,8 @@ FlowRouter.route("/lists/:listId", {
 
 // XXX this should be replaced by promises, probably...
 Tracker.autorun(function (computation) {
-  // Are all of the subscriptions done yet?
-  subsReady = _.all(handles, function (handle) {
-    return handle.ready();
-  });
-
-  // If they are, and we are at the root route, we should go to a valid list
-  if (subsReady && FlowRouter.getRouteName() === "root") {
+  // If the data's ready, and we are at the root route, we should go to a valid list
+  if (FlowRouter.subsReady() && FlowRouter.getRouteName() === "root") {
     FlowRouter.go("todoList", { listId: Lists.findOne()._id });
     computation.stop();
   }

--- a/react-todos/client/routes.jsx
+++ b/react-todos/client/routes.jsx
@@ -34,7 +34,7 @@ Tracker.autorun(function (computation) {
   });
 
   // If they are, and we are at the root route, we should go to a valid list
-  if (subsReady && FlowRouter.current().name === "root") {
+  if (subsReady && FlowRouter.getRouteName() === "root") {
     FlowRouter.go("todoList", { listId: Lists.findOne()._id });
     computation.stop();
   }


### PR DESCRIPTION
[`FlowRouter.current()`](https://github.com/meteorhacks/flow-router#flowroutercurrent) is not reactive. On the other hand, [`FlowRouter.getRouteName()`](https://github.com/meteorhacks/flow-router#flowroutergetroutename) is, and is fine-grained :smile:.

Also check [this](https://github.com/meteorhacks/flow-router#subscription-management) on subscription management.