### PR TITLE
Fixes Issue #4 -  Leaking React Components

### DIFF
--- a/react-template-helper/react-template-helper.js
+++ b/react-template-helper/react-template-helper.js
@@ -1,6 +1,8 @@
 Template.React.onRendered(function () {
   var parentTemplate = parentTemplateName();
   var container = this.firstNode.parentNode;
+  this._blazeId = Math.random().toString();
+  container.setAttribute('data-blaze-id', this._blazeId);
 
   this.autorun(function (c) {
     var data = Blaze.getData();
@@ -26,6 +28,14 @@ Template.React.onRendered(function () {
     var props = _.omit(data, 'component');
     React.render(React.createElement(comp, props), container);
   });
+});
+
+Template.React.onDestroyed(function () {
+  var selector = "[data-blaze-id='" + this._blazeId + "']";
+  var container = document.querySelectorAll(selector)[0];
+  if (container) {
+    React.unmountComponentAtNode(container);
+  }
 });
 
 // Gets the name of the template inside of which this instance of `{{>


### PR DESCRIPTION
Patch for issue #4 where a React component doesn’t get un-mounted
before  Blaze destroys it’s own view.

Creates a random id and attaches it to the blaze wrapper container with
a data attribute. This value is stored in the template instance so it
can be accessed at `onDestroy`.

Sample repo can be used to verify proper use. Inspector shows an empty
Blaze container div after un-mounting and before exiting `onDestroyed`

https://github.com/AdamBrodzinski/react-blaze-helper-fix

`PACKAGE_DIRS=` was used to link this patch to repo above.