### PR TITLE
Refactor Leaderboard App

### DIFF
--- a/examples/leaderboard/leaderboard.html
+++ b/examples/leaderboard/leaderboard.html
@@ -15,7 +15,7 @@
 
 <template name="leaderboard">
   <div>
-    {{> React component=Leaderboard
+    {{> React component=PlayerList
       players=players.fetch
       selectedPlayerId=selectedPlayerId }}
   </div>

--- a/examples/leaderboard/leaderboard.jsx
+++ b/examples/leaderboard/leaderboard.jsx
@@ -15,8 +15,8 @@ if (Meteor.isClient) {
     selectedPlayerId() {
       return Session.get("selectedPlayer");
     },
-    Leaderboard() {
-      return Leaderboard;
+    PlayerList() {
+      return PlayerList;
     }
   });
 

--- a/examples/leaderboard/player.jsx
+++ b/examples/leaderboard/player.jsx
@@ -2,28 +2,59 @@
 
 Leaderboard = React.createClass({
   propTypes: {
-    selectedPlayerId: React.PropTypes.string,
     players: React.PropTypes.array.isRequired
   },
-  selectPlayer(playerId) {
-    Session.set("selectedPlayer", playerId);
+
+  setSelectedPlayer(id) {
+    Session.set("selectedPlayer", id);
   },
+
+  getSelectedPlayer() {
+    return Session.get("selectedPlayer");
+  },
+
   render() {
-    var self = this;
-
-    return <ul className="leaderboard">{
-      this.props.players.map((player) => {
-        var className = "player";
-        if (this.props.selectedPlayerId === player._id) {
-          className += " selected";
-        }
-
-        return <li className={ className } key={ player._id }
-            onClick={ self.selectPlayer.bind(self, player._id) }>
-          <span className="name">{ player.name }</span>
-          <span className="score">{ player.score }</span>
-        </li>
-      })
-    }</ul>
+    return (
+     <ul className="leaderboard">
+       {
+         this.props.players.map((player) => {
+           return (
+             <PlayerItem
+               key={ player._id }
+               getSelectedPlayer={ this.getSelectedPlayer }
+               setSelectedPlayer={ this.setSelectedPlayer }
+               player={player} />
+           );
+         })
+       }
+     </ul>
+    );
   }
-})
+});
+
+
+PlayerItem = React.createClass({
+  handleClick() {
+    var playerId = this.props.player._id;
+    this.props.setSelectedPlayer(playerId);
+  },
+
+  getClassName() {
+    var selectedId = this.props.getSelectedPlayer();
+    var playerId = this.props.player._id;
+
+    return (selectedId === playerId) ? 'player selected' : 'player';
+  },
+
+  render() {
+    var player = this.props.player;
+
+    return (
+      <li className={ this.getClassName() } onClick={ this.handleClick }>
+        <span className="name">{ player.name }</span>
+        <span className="score">{ player.score }</span>
+      </li>
+    );
+  }
+});
+

--- a/examples/leaderboard/player.jsx
+++ b/examples/leaderboard/player.jsx
@@ -2,15 +2,12 @@
 
 PlayerList = React.createClass({
   propTypes: {
+    selectedPlayerId: React.PropTypes.string,
     players: React.PropTypes.array.isRequired
   },
 
   setSelectedPlayer(id) {
     Session.set("selectedPlayer", id);
-  },
-
-  getSelectedPlayer() {
-    return Session.get("selectedPlayer");
   },
 
   render() {
@@ -21,7 +18,7 @@ PlayerList = React.createClass({
            return (
              <PlayerItem
                key={ player._id }
-               getSelectedPlayer={ this.getSelectedPlayer }
+               selectedPlayerId={ this.props.selectedPlayerId }
                setSelectedPlayer={ this.setSelectedPlayer }
                player={player} />
            );
@@ -40,9 +37,8 @@ PlayerItem = React.createClass({
   },
 
   getClassName() {
-    var selectedId = this.props.getSelectedPlayer();
+    var selectedId = this.props.selectedPlayerId;
     var playerId = this.props.player._id;
-
     return (selectedId === playerId) ? 'player selected' : 'player';
   },
 

--- a/examples/leaderboard/player.jsx
+++ b/examples/leaderboard/player.jsx
@@ -1,6 +1,6 @@
 // @jsx React.DOM
 
-Leaderboard = React.createClass({
+PlayerList = React.createClass({
   propTypes: {
     players: React.PropTypes.array.isRequired
   },


### PR DESCRIPTION
Hello,

I noticed that some of the examples were not following common React patterns. I refactored the Leaderboard app a bit to conform more closely to React idioms. This changed the structure a little more that I anticipated so I hope it's not going too far. I can also split `PlayerItem` out into another file too.

Would you be open to converting the increment button section to a react template too? This would leave Blaze to handle just the HTML static shell.

Ideally from a React perspective there would be a topmost `LeaderBoardContainer` React component wrapping both the increment component and `PlayerList` component and that would get inserted into the body but I wasn't sure how much of the Blaze logic you wanted to leave.

Cheers!
Adam