### PR TITLE
Fix react-meteor-data for server rendering

### DIFF
--- a/packages/react-meteor-data/meteor-data-mixin.jsx
+++ b/packages/react-meteor-data/meteor-data-mixin.jsx
@@ -55,6 +55,12 @@ class MeteorDataManager {
     if (! component.getMeteorData) {
       return null;
     }
+    
+    // When rendering on the server, we don't want to use the Tracker.
+    // We only do the first rendering on the server so we can get the data right away
+    if (Meteor.isServer) {
+      return component.getMeteorData();
+    }
 
     if (this.computation) {
       this.computation.stop();


### PR DESCRIPTION
When using the mixin `ReactMeteorData`, it is not taking into account that it might be executed on the server. Because it uses the Tracker (and it doesn't work on the server), it throws this error:

```
I20150730-19:37:02.216(-4)? Exception in callback of async function: Error: Can't call yield in a noYieldsAllowed block!
I20150730-19:37:02.217(-4)?     at Function.Fiber.yield (packages/meteor/fiber_helpers.js:8:1)
I20150730-19:37:02.218(-4)?     at Function.wait (/home/benoit/.meteor/packages/meteor-tool/.1.1.3.4sddkj++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/server-lib/node_modules/fibers/future.js:183:14)
I20150730-19:37:02.218(-4)?     at Object.Future.wait (/home/benoit/.meteor/packages/meteor-tool/.1.1.3.4sddkj++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/server-lib/node_modules/fibers/future.js:397:10)
I20150730-19:37:02.218(-4)?     at [object Object]._.extend._nextObject (packages/mongo/mongo_driver.js:929:1)
I20150730-19:37:02.219(-4)?     at [object Object]._.extend.forEach (packages/mongo/mongo_driver.js:963:1)
I20150730-19:37:02.219(-4)?     at [object Object]._.extend.map (packages/mongo/mongo_driver.js:973:1)
I20150730-19:37:02.219(-4)?     at [object Object]._.extend.fetch (packages/mongo/mongo_driver.js:997:1)
I20150730-19:37:02.220(-4)?     at [object Object].Cursor.(anonymous function) [as fetch] (packages/mongo/mongo_driver.js:812:1)
I20150730-19:37:02.221(-4)?     at [object Object].React.createClass.getMeteorData (./app.jsx:30:31)
I20150730-19:37:02.221(-4)?     at packages/react-meteor-data/meteor-data-mixin.jsx:73:28
```

When we are using ReactMeteorData on the server, we should get the `getMeteorData()` straight away. This PR is fixing the problem. Here is a very simple example of server-side rendering with react-router:

```javascript
TestItems = new Mongo.Collection('TestItems');

if (Meteor.isServer) {
  if (TestItems.find().count() === 0) {
    TestItems.insert({ content: 'line 1' });
    TestItems.insert({ content: 'line 2' });
    TestItems.insert({ content: 'line 3' });
  }
}

const {Router, Route, Link} = ReactRouter;

Test = React.createClass({
  render() {
    return (
      <ul>
        {this.props.items.map(function(item) {
          return <li key={item._id}>{item.content}</li>;
        })}
      </ul>
    );
  }
});

App = React.createClass({
  mixins: [ReactMeteorData],

  getMeteorData() {
    return {
      items: TestItems.find().fetch()
    };
  },

  render() {
    console.log(this.data.items);
    return (
      <div>
        <h1>Test!</h1>
        <Test items={this.data.items} />
      </div>
    );
  }
});

AppRoutes = (
  <Route path="/" component={App} />
);

if (Meteor.isClient) {
  const {history} = ReactRouter.lib.BrowserHistory;

  Meteor.startup(function() {
    React.render((
      <Router history={history} children={AppRoutes} />
    ), document.getElementById('react-root'));
  });
}

if (Meteor.isServer) {
  FastRender.route('/', function() {
    this.subscribe('TestItems');
  });

  Meteor.publish('TestItems', function () {
    return TestItems.find();
  });


  const Location = ReactRouter.lib.Location;
  const url = Npm.require('url');

  WebApp.rawConnectHandlers.use(function(req, res, next) {
    var originalWrite = res.write;
    res.write = function(data) {
      if(typeof data === 'string') {
        var parsedUrl = url.parse(req.url);
        var location = new Location(parsedUrl.pathname, parsedUrl.query);

        Router.run(AppRoutes, location, function(error, initialState, transition) {
          var html = '';

          if (initialState) {
            Meteor.bindEnvironment(function() {
              html = React.renderToString(
                <Router {...initialState} children={AppRoutes} />
              );
            })();
          }

          var reactRoot = '<div id="react-root">' + html + '</div>';
          data = data.replace('<body>', '<body>' + reactRoot);
        });
      }

      originalWrite.call(this, data);
    };

    next();
  });
}
```