### PR TITLE
Use the BabelCompiler exported by babel-compiler

### DIFF
--- a/packages/jsx/jsx-plugin.js
+++ b/packages/jsx/jsx-plugin.js
@@ -1,71 +1,7 @@
-function BabelCompiler() {}
-
-var BCp = BabelCompiler.prototype;
-
-BCp.processFilesForTarget = function (inputFiles) {
-  inputFiles.forEach(function (inputFile) {
-    var source = inputFile.getContentsAsString();
-    var inputFilePath = inputFile.getPathInPackage();
-    var outputFilePath = inputFile.getPathInPackage();
-    var fileOptions = inputFile.getFileOptions();
-    var toBeAdded = {
-      sourcePath: inputFilePath,
-      path: outputFilePath,
-      data: source,
-      hash: inputFile.getSourceHash(),
-      sourceMap: null,
-      bare: !! fileOptions.bare
-    };
-
-    if (fileOptions.transpile !== false) {
-      var targetCouldBeInternetExplorer8 =
-        inputFile.getArch() === "web.browser";
-
-      var babelOptions = Babel.getDefaultOptions({
-        // Perform some additional transformations to improve
-        // compatibility in older browsers (e.g. wrapping named function
-        // expressions, per http://kiro.me/blog/nfe_dilemma.html).
-        jscript: targetCouldBeInternetExplorer8,
-        react: true
-      });
-
-      babelOptions.sourceMap = true;
-      babelOptions.filename = inputFilePath;
-      babelOptions.sourceFileName = "/" + inputFilePath;
-      babelOptions.sourceMapName = "/" + outputFilePath + ".map";
-
-      try {
-        var result = Babel.compile(source, babelOptions);
-      } catch (e) {
-        if (e.loc) {
-          inputFile.error({
-            message: e.message,
-            sourcePath: inputFilePath,
-            line: e.loc.line,
-            column: e.loc.column,
-          });
-
-          return;
-        }
-
-        throw e;
-      }
-
-      toBeAdded.data = result.code;
-      toBeAdded.hash = result.hash;
-      toBeAdded.sourceMap = result.map;
-    }
-
-    inputFile.addJavaScript(toBeAdded);
-  });
-};
-
-BCp.setDiskCacheDirectory = function (cacheDir) {
-  Babel.setCacheDir(cacheDir);
-};
-
 Plugin.registerCompiler({
   extensions: ['jsx'],
 }, function () {
-  return new BabelCompiler();
+  return new BabelCompiler({
+    react: true
+  });
 });

--- a/packages/jsx/package.js
+++ b/packages/jsx/package.js
@@ -8,7 +8,7 @@ Package.describe({
 
 Package.registerBuildPlugin({
   name: 'compile-jsx',
-  use: ['babel-compiler@5.8.22-rc.0'],
+  use: ['babel-compiler@5.8.22-rc.1'],
   sources: [
     'jsx-plugin.js'
   ]


### PR DESCRIPTION
Only merge this when the following commit is published as a 1.2 RC: https://github.com/meteor/meteor/commit/291c8fe344de78ce98ce16af9a993e348bff000b

Don't forget to update the `babel-compiler` reference in `packages/jsx/package.js` to the new version.