### PR TITLE
Fix the typo error which does not expose ReactDOMServer

### DIFF
--- a/packages/react-runtime/react-runtime.js
+++ b/packages/react-runtime/react-runtime.js
@@ -3,14 +3,14 @@ if (Package["react-runtime-dev"]) {
   ReactDOM = Package["react-runtime-dev"].ReactDOMDev;
 
   if (Meteor.isServer) {
-    ReactDOMServer = Package["react-runtime-dev"].ReactDOMServer;
+    ReactDOMServer = Package["react-runtime-dev"].ReactDOMServerDev;
   }
 } else if (Package["react-runtime-prod"]) {
   React = Package["react-runtime-prod"].ReactProd;
   ReactDOM = Package["react-runtime-prod"].ReactDOMProd;
 
   if (Meteor.isServer) {
-    ReactDOMServer = Package["react-runtime-prod"].ReactDOMServer;
+    ReactDOMServer = Package["react-runtime-prod"].ReactDOMServerProd;
   }
 } else {
   // not sure how this can happen


### PR DESCRIPTION
Right now, React DOM Server is not exposing properly. This will fix it.