### PR TITLE
update cosmos:browserify to 0.8.3 to fix cache use

### DIFF
--- a/packages/react-runtime-dev/package.js
+++ b/packages/react-runtime-dev/package.js
@@ -26,7 +26,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.use('cosmos:browserify@0.8.1');
+  api.use('cosmos:browserify@0.8.3');
   api.addFiles('detect-shims.js');
   api.addFiles('shams.js');
   api.addFiles('react.browserify.js');

--- a/packages/react-runtime-prod/package.js
+++ b/packages/react-runtime-prod/package.js
@@ -25,7 +25,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.use('cosmos:browserify@0.8.1');
+  api.use('cosmos:browserify@0.8.3');
   api.addFiles('shams.js');
   api.addFiles('react.browserify.js');
   api.addFiles('react.browserify.options.json');


### PR DESCRIPTION
When browserifying a file in both the client and server scope with different exports the `getCacheKey()` of cosmos:browserify doesn't work right because it considers the `file.getDeclaredExports()`. Version 0.8.3 avoids the problem by not including the exports in the cache key.

See [this issue](https://github.com/elidoran/cosmos-browserify/issues/29) for babble about it.