### PR TITLE
Remove webcomponents.js from includes list.

### DIFF
--- a/packages/react-runtime-dev/react.browserify.options.json
+++ b/packages/react-runtime-dev/react.browserify.options.json
@@ -156,7 +156,6 @@
     "react/lib/traverseAllChildren",
     "react/lib/update",
     "react/lib/validateDOMNesting",
-    "react/lib/webcomponents",
     "react-dom",
     "react-dom/server"
   ],

--- a/packages/react-runtime-prod/react.browserify.options.json
+++ b/packages/react-runtime-prod/react.browserify.options.json
@@ -156,7 +156,6 @@
     "react/lib/traverseAllChildren",
     "react/lib/update",
     "react/lib/validateDOMNesting",
-    "react/lib/webcomponents",
     "react-dom",
     "react-dom/server"
   ],


### PR DESCRIPTION
This file (from Polymer) includes some ES5 getters which are incompatible with IE8. We include it incase people want to `require('react/lib/webcomponents)`, however I don't think this file is truly a part of react (I think it ends up in the npm module by accident perhaps? not sure).

See https://github.com/meteor/meteor/issues/5791