### PR TITLE
ensure this.container is set in the onDestroyed callback before passing to ReactDOM to unmount it

### DIFF
--- a/packages/react-template-helper/react-template-helper.js
+++ b/packages/react-template-helper/react-template-helper.js
@@ -42,7 +42,8 @@ Template.React.onRendered(function () {
 });
 
 Template.React.onDestroyed(function () {
-  ReactDOM.unmountComponentAtNode(this.container);
+  if (this.container)
+    ReactDOM.unmountComponentAtNode(this.container);
 });
 
 // Gets the name of the template inside of which this instance of `{{>


### PR DESCRIPTION
I ran into a case where the ```onRendered``` callback hadn't been called yet, but the ```onDestroyed``` was called first. Currently my workaround is to create a div ```onCreated``` and set ```this.container``` equal to it, but it would be nice if this was fixed in the package by ensuring that ```this.container``` is set before trying to utilize it.