### PR TITLE
Allow using component name instead of component

### DIFF
--- a/packages/react-template-helper/react-template-helper.js
+++ b/packages/react-template-helper/react-template-helper.js
@@ -8,8 +8,11 @@ Template.React.onRendered(function () {
 
   this.autorun(function (c) {
     var data = Blaze.getData();
-
+    var compName = data && data.componentName;
     var comp = data && data.component;
+    if(compName){
+        comp = window[compName];
+    }
     if (! comp) {
       throw new Error(
         "In template \"" + parentTemplate + "\", call to `{{> React ... }}` missing " +


### PR DESCRIPTION
It would be great if we can just use the component name instead of a component reference.Why can't we just pick the component from global? That would remove the need for a template helper returning the component. This small change won't break anything, just adds componentName option. With this change package can be used just with:

```
{{> React componentName="MyComponent" prop1="Hello"}}
```