### PR TITLE
Added new `createContainer` API.

### DIFF
--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -1,4 +1,4 @@
-ReactMeteorData = {
+const ReactMeteorData = {
   componentWillMount() {
     this.data = {};
     this._meteorDataManager = new MeteorDataManager(this);
@@ -29,7 +29,7 @@ ReactMeteorData = {
   },
   componentWillUnmount() {
     this._meteorDataManager.dispose();
-  }
+  },
 };
 
 // A class to keep the state and utility methods needed to manage
@@ -147,3 +147,5 @@ class MeteorDataManager {
     this.oldData = newData;
   }
 }
+
+export default ReactMeteorData;

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -1,0 +1,39 @@
+/**
+ * Container helper using react-meteor-data.
+ */
+
+import React from 'react';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+
+import ReactMeteorData from './ReactMeteorData.jsx';
+
+export default function createContainer(options = {}, Component) {
+  let expandedOptions = options;
+  if (typeof options === 'function') {
+    expandedOptions = {
+      getMeteorData: options,
+    };
+  }
+
+  const {
+    getMeteorData,
+    pure = true,
+  } = expandedOptions;
+
+  const mixins = [ReactMeteorData];
+  if (pure) {
+    mixins.push(PureRenderMixin);
+  }
+
+  /* eslint-disable react/prefer-es6-class */
+  return React.createClass({
+    displayName: 'MeteorDataContainer',
+    mixins,
+    getMeteorData() {
+      return getMeteorData(this.props);
+    },
+    render() {
+      return <Component {...this.props} {...this.data} />;
+    },
+  });
+}

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -1,19 +1,19 @@
 Package.describe({
-  name: "react-meteor-data",
-  summary: "React mixin for reactively tracking Meteor data",
+  name: 'react-meteor-data',
+  summary: 'React mixin for reactively tracking Meteor data',
   version: '0.2.5',
   documentation: 'README.md',
-  git: 'https://github.com/meteor/react-packages'
+  git: 'https://github.com/meteor/react-packages',
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom('METEOR@1.1.0.2');
+  api.versionsFrom('1.3-beta.12');
   api.use('tracker');
-  api.use('jsx@0.2.4');
+  api.use('ecmascript');
 
   api.export(['ReactMeteorData']);
 
-  api.addFiles('meteor-data-mixin.jsx');
+  api.mainModule('react-meteor-data.jsx');
 });
 
 Package.onTest(function (api) {

--- a/packages/react-meteor-data/react-meteor-data.jsx
+++ b/packages/react-meteor-data/react-meteor-data.jsx
@@ -1,0 +1,4 @@
+import createContainer from './createContainer.jsx';
+import ReactMeteorData from './ReactMeteorData.jsx';
+
+export { createContainer, ReactMeteorData };

--- a/tests/runtime-harness/.meteor/packages
+++ b/tests/runtime-harness/.meteor/packages
@@ -17,6 +17,6 @@ standard-minifier-js    # JS minifier run for production mode
 es5-shim                # ECMAScript 5 compatibility for older browsers.
 ecmascript              # Enable ECMAScript2015+ syntax in app code
 
-avital:mocha   # An excellent default test driver package.
+avital:mocha@2.1.0_9   # An excellent default test driver package.
 practicalmeteor:mocha-console-reporter
 react-runtime

--- a/tests/runtime-harness/.meteor/versions
+++ b/tests/runtime-harness/.meteor/versions
@@ -1,6 +1,6 @@
 allow-deny@1.0.1-beta.12
 autoupdate@1.2.5-beta.12
-avital:mocha@2.1.0_8
+avital:mocha@2.1.0_9
 babel-compiler@6.5.0-beta.12
 babel-runtime@0.1.5-beta.12
 base64@1.0.5-beta.12
@@ -72,6 +72,7 @@ standard-minifier-js@1.0.3-beta.12
 templating@1.1.6-beta.12
 templating-tools@1.0.1-beta.12
 tmeasday:check-npm-versions@0.1.1
+tmeasday:test-reporter-helpers@0.2.0
 tracker@1.0.10-beta.12
 ui@1.0.8
 underscore@1.0.5-beta.12


### PR DESCRIPTION
I've updated the `react-meteor-data` package to provide the `createContainer` API as discussed elsewhere (notably https://github.com/meteor/react-packages/issues/169).

@stubailo I'm assigning this to you again; apologies ;)