### PR TITLE
Fix markdown typo in 'React article' link

### DIFF
--- a/packages/react-meteor-data/README.md
+++ b/packages/react-meteor-data/README.md
@@ -28,4 +28,4 @@ Foo = React.createClass({
 });
 ```
 
-For more information, see the React article](http://guide.meteor.com/react.html) in the Meteor Guide.
+For more information, see the [React article](http://guide.meteor.com/react.html) in the Meteor Guide.


### PR DESCRIPTION
React article] -> [React article]