### PR TITLE
Don't update data in place, instead create a new object

### DIFF
--- a/docs/analytics.js
+++ b/docs/analytics.js
@@ -1,6 +1,0 @@
-(function(d,s,i,r) {
-  if (d.getElementById(i)){return;}
-  var n=d.createElement(s),e=d.getElementsByTagName(s)[0];
-  n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/520701.js';
-  e.parentNode.insertBefore(n, e);
-})(document,"script","hs-analytics",300000);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,5 +9,3 @@ pages:
 - React components in Meteor templates: react-template-helper.md
 - Setting up routing with React: routing.md
 - Community Meteor + React tools: community.md
-extra_javascript:
-- analytics.js

--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -129,9 +129,8 @@ class MeteorDataManager {
       throw new Error("Expected object returned from getMeteorData");
     }
     // update componentData in place based on newData
-    for (let key in newData) {
-      component.data[key] = newData[key];
-    }
+    component.data = newData;
+
     // if there is oldData (which is every time this method is called
     // except the first), delete keys in newData that aren't in
     // oldData.  don't interfere with other keys, in case we are


### PR DESCRIPTION
It seems like the old implementation cared about other things using `this.data` but I don't think that's reasonable anymore. On the other hand, keeping the `this.data` object with the same reference actively breaks Redux because it relies on comparing prop references to detect changes.