### PR TITLE
Add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "react-packages",
+  "version": "1.4.1.1",
   "description": "Meteor packages for a great React developer experience",
   "scripts": {
     "lint": "eslint . || true",


### PR DESCRIPTION
Since it's 2016, I'm trying to use this package via npm instead of isobuild, like so:
`npm install --save meteor/react-packages#react@15.0.1`

But since this package doesn't provide a `version` in its `package.json` installing it via `npm` fails:

```
npm ERR! addLocal Could not install /var/folders/sp/0kz1lsqn0fg37x3tt94dvdsm0000gn/T/npm-4297-4996edd2/git-cache-c1427690/057e1b9fbefbbc724f501ca27c1036329deb9124
npm ERR! addLocal Could not install /var/folders/sp/0kz1lsqn0fg37x3tt94dvdsm0000gn/T/npm-4297-4996edd2/git-cache-ab38a6fd/057e1b9fbefbbc724f501ca27c1036329deb9124
npm ERR! addLocal Could not install /var/folders/sp/0kz1lsqn0fg37x3tt94dvdsm0000gn/T/npm-4297-4996edd2/git-cache-cada1fdf/057e1b9fbefbbc724f501ca27c1036329deb9124
npm ERR! Darwin 15.6.0
npm ERR! argv "/Users/andy/.nvm/versions/node/v5.12.0/bin/node" "/Users/andy/.nvm/versions/node/v5.12.0/bin/npm" "i" "--save-dev" "--force" "meteor/react-packages#react@15.0.1"
npm ERR! node v5.12.0
npm ERR! npm  v3.8.6

npm ERR! No version provided in package.json
```

This would fix that issue.
