### PR TITLE
export createContainer (in the package.js)

### DIFF
--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -12,7 +12,7 @@ Package.onUse(function (api) {
   api.use('ecmascript');
   api.use('tmeasday:check-npm-versions@0.2.0');
 
-  api.export(['ReactMeteorData']);
+  api.export(['ReactMeteorData', 'createContainer']);
 
   api.mainModule('react-meteor-data.jsx');
 });


### PR DESCRIPTION
after doing `console.log(require('meteor/react-meteor-data'));` I realized that createContainer is not exported by the package. And, it's normal because in the package.js, only `ReactMeteorData` is exported.

So even the trivial example starting with `import { createContainer } from 'meteor/react-meteor-data';` fails.

I just added `createContainer` in the export like it should be.
