### PR TITLE
Add getInitialState option to createContainer

### DIFF
--- a/packages/react-meteor-data/README.md
+++ b/packages/react-meteor-data/README.md
@@ -40,3 +40,33 @@ The first argument to `createContainer` is a reactive function that will get re-
 The returned component will, when rendered, render the second argument (the "lower-order" component) with its provided `props` in addition to the result of the reactive function. So `Foo` will receive `FooContainer`'s `props` as well as `{currentUser, listLoading, tasks}`.
 
 For more information, see the [React article](http://guide.meteor.com/react.html) in the Meteor Guide.
+
+#### Usage with ReactiveVar
+
+You can use `createContainer` with Meteor's `ReactiveVar`s by providing a `getInitialState` function.
+
+```js
+import { createContainer } from 'meteor/react-meteor-data';
+
+export default FooContainer = createContainer({
+  getInitialState(props) {
+    return {
+      loadCount: new ReactiveVar(props.initialLoadCount)
+    };
+  },
+  getMeteorData(props, state) {
+    // will resubscribe when loadCount changes
+    const { loadCount } = state
+    const handle = Meteor.subscribe('todoList', props.id, loadCount.get());
+
+    return {
+      loadMore() {
+        loadCount.set(loadCount.get() + 5);
+      },
+      currentUser: Meteor.user(),
+      listLoading: ! handle.ready(),
+      tasks: Tasks.find({ listId: props.id }).fetch(),
+    };
+  }
+}, Foo);
+```

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -16,6 +16,7 @@ export default function createContainer(options = {}, Component) {
   }
 
   const {
+    getInitialState = function () { return null; },
     getMeteorData,
     pure = true,
   } = expandedOptions;
@@ -29,8 +30,11 @@ export default function createContainer(options = {}, Component) {
   return React.createClass({
     displayName: 'MeteorDataContainer',
     mixins,
+    getInitialState() {
+      return getInitialState(this.props);
+    },
     getMeteorData() {
-      return getMeteorData(this.props);
+      return getMeteorData(this.props, this.state);
     },
     render() {
       return <Component {...this.props} {...this.data} />;

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -34,7 +34,7 @@ export default function createContainer(options = {}, Component) {
       return getInitialState(this.props);
     },
     getMeteorData() {
-      return getMeteorData(this.props, this.state);
+      return getMeteorData.call({ state: this.state }, this.props, this.state);
     },
     render() {
       return <Component {...this.props} {...this.data} />;


### PR DESCRIPTION
This addresses #203 and adds an option to give a `getInitialState` function to `createContainer`. 

As a former Blaze user, I can't understand how people use React without `ReactiveVar`s, and this PR makes it possible to use them with the best-practice method `createContainer`.