### PR TITLE
Convert ReactMeteorData to a Higher-Order Component

### DIFF
--- a/packages/react-meteor-data/README.md
+++ b/packages/react-meteor-data/README.md
@@ -10,10 +10,10 @@ To install the package, use `meteor add`:
 meteor add react-meteor-data
 ```
 
-You'll also need to install `react`, `create-react-class`, and `react-addons-pure-render-mixin` if you have not already:
+You'll also need to install `react` if you have not already:
 
 ```bash
-npm install --save react create-react-class react-addons-pure-render-mixin
+npm install --save react
 ```
 
 ### Usage

--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -1,53 +1,53 @@
 import React from 'react';
 
-export function connect({ getMeteorData, pure = true }, WrappedComponent) {
+export function connect({ getMeteorData, pure = true }) {
   const BaseComponent = pure ? React.PureComponent : React.Component;
 
-  class ReactMeteorData extends BaseComponent {
-    getMeteorData() {
-      return getMeteorData(this.props);
-    }
-
-    componentWillMount() {
-      this.data = {};
-      this._meteorDataManager = new MeteorDataManager(this);
-      const newData = this._meteorDataManager.calculateData();
-      this._meteorDataManager.updateData(newData);
-    }
-
-    componentWillUpdate(nextProps, nextState) {
-      const saveProps = this.props;
-      const saveState = this.state;
-      let newData;
-      try {
-        // Temporarily assign this.state and this.props,
-        // so that they are seen by getMeteorData!
-        // This is a simulation of how the proposed Observe API
-        // for React will work, which calls observe() after
-        // componentWillUpdate and after props and state are
-        // updated, but before render() is called.
-        // See https://github.com/facebook/react/issues/3398.
-        this.props = nextProps;
-        this.state = nextState;
-        newData = this._meteorDataManager.calculateData();
-      } finally {
-        this.props = saveProps;
-        this.state = saveState;
+  return WrappedComponent => (
+    class ReactMeteorData extends BaseComponent {
+      getMeteorData() {
+        return getMeteorData(this.props);
       }
 
-      this._meteorDataManager.updateData(newData);
-    }
+      componentWillMount() {
+        this.data = {};
+        this._meteorDataManager = new MeteorDataManager(this);
+        const newData = this._meteorDataManager.calculateData();
+        this._meteorDataManager.updateData(newData);
+      }
 
-    componentWillUnmount() {
-      this._meteorDataManager.dispose();
-    }
+      componentWillUpdate(nextProps, nextState) {
+        const saveProps = this.props;
+        const saveState = this.state;
+        let newData;
+        try {
+          // Temporarily assign this.state and this.props,
+          // so that they are seen by getMeteorData!
+          // This is a simulation of how the proposed Observe API
+          // for React will work, which calls observe() after
+          // componentWillUpdate and after props and state are
+          // updated, but before render() is called.
+          // See https://github.com/facebook/react/issues/3398.
+          this.props = nextProps;
+          this.state = nextState;
+          newData = this._meteorDataManager.calculateData();
+        } finally {
+          this.props = saveProps;
+          this.state = saveState;
+        }
 
-    render() {
-      return <WrappedComponent {...this.props} {...this.data} />;
-    }
-  }
+        this._meteorDataManager.updateData(newData);
+      }
 
-  return ReactMeteorData;
+      componentWillUnmount() {
+        this._meteorDataManager.dispose();
+      }
+
+      render() {
+        return <WrappedComponent {...this.props} {...this.data} />;
+      }
+    }
+  );
 }
 
 // A class to keep the state and utility methods needed to manage

--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -1,36 +1,52 @@
-const ReactMeteorData = {
-  componentWillMount() {
-    this.data = {};
-    this._meteorDataManager = new MeteorDataManager(this);
-    const newData = this._meteorDataManager.calculateData();
-    this._meteorDataManager.updateData(newData);
-  },
-  componentWillUpdate(nextProps, nextState) {
-    const saveProps = this.props;
-    const saveState = this.state;
-    let newData;
-    try {
-      // Temporarily assign this.state and this.props,
-      // so that they are seen by getMeteorData!
-      // This is a simulation of how the proposed Observe API
-      // for React will work, which calls observe() after
-      // componentWillUpdate and after props and state are
-      // updated, but before render() is called.
-      // See https://github.com/facebook/react/issues/3398.
-      this.props = nextProps;
-      this.state = nextState;
-      newData = this._meteorDataManager.calculateData();
-    } finally {
-      this.props = saveProps;
-      this.state = saveState;
+import React from 'react';
+
+export function connect({ getMeteorData }, WrappedComponent) {
+  class ReactMeteorData extends React.Component {
+    getMeteorData() {
+      return getMeteorData(this.props);
     }
 
-    this._meteorDataManager.updateData(newData);
-  },
-  componentWillUnmount() {
-    this._meteorDataManager.dispose();
-  },
-};
+    componentWillMount() {
+      this.data = {};
+      this._meteorDataManager = new MeteorDataManager(this);
+      const newData = this._meteorDataManager.calculateData();
+      this._meteorDataManager.updateData(newData);
+    }
+
+    componentWillUpdate(nextProps, nextState) {
+      const saveProps = this.props;
+      const saveState = this.state;
+      let newData;
+      try {
+        // Temporarily assign this.state and this.props,
+        // so that they are seen by getMeteorData!
+        // This is a simulation of how the proposed Observe API
+        // for React will work, which calls observe() after
+        // componentWillUpdate and after props and state are
+        // updated, but before render() is called.
+        // See https://github.com/facebook/react/issues/3398.
+        this.props = nextProps;
+        this.state = nextState;
+        newData = this._meteorDataManager.calculateData();
+      } finally {
+        this.props = saveProps;
+        this.state = saveState;
+      }
+
+      this._meteorDataManager.updateData(newData);
+    }
+
+    componentWillUnmount() {
+      this._meteorDataManager.dispose();
+    }
+
+    render() {
+      return <WrappedComponent {...this.props} {...this.data} />;
+    }
+  }
+
+  return ReactMeteorData;
+}
 
 // A class to keep the state and utility methods needed to manage
 // the Meteor data for a component.
@@ -51,7 +67,7 @@ class MeteorDataManager {
   calculateData() {
     const component = this.component;
 
-    if (! component.getMeteorData) {
+    if (!component.getMeteorData) {
       return null;
     }
 
@@ -79,11 +95,11 @@ class MeteorDataManager {
           try {
             component.setState = () => {
               throw new Error(
-"Can't call `setState` inside `getMeteorData` as this could cause an endless" +
-" loop. To respond to Meteor data changing, consider making this component" +
-" a \"wrapper component\" that only fetches data and passes it in as props to" +
-" a child component. Then you can use `componentWillReceiveProps` in that" +
-" child component.");
+                "Can't call `setState` inside `getMeteorData` as this could cause an endless" +
+                " loop. To respond to Meteor data changing, consider making this component" +
+                " a \"wrapper component\" that only fetches data and passes it in as props to" +
+                " a child component. Then you can use `componentWillReceiveProps` in that" +
+                " child component.");
             };
 
             data = component.getMeteorData();
@@ -111,9 +127,9 @@ class MeteorDataManager {
       Object.keys(data).forEach(function (key) {
         if (data[key] instanceof Package.mongo.Mongo.Cursor) {
           console.warn(
-  "Warning: you are returning a Mongo cursor from getMeteorData. This value " +
-  "will not be reactive. You probably want to call `.fetch()` on the cursor " +
-  "before returning it.");
+            "Warning: you are returning a Mongo cursor from getMeteorData. This value " +
+            "will not be reactive. You probably want to call `.fetch()` on the cursor " +
+            "before returning it.");
         }
       });
     }
@@ -125,7 +141,7 @@ class MeteorDataManager {
     const component = this.component;
     const oldData = this.oldData;
 
-    if (! (newData && (typeof newData) === 'object')) {
+    if (!(newData && (typeof newData) === 'object')) {
       throw new Error("Expected object returned from getMeteorData");
     }
     // update componentData in place based on newData

--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-export function connect({ getMeteorData }, WrappedComponent) {
-  class ReactMeteorData extends React.Component {
+export function connect({ getMeteorData, pure = true }, WrappedComponent) {
+  const BaseComponent = pure ? React.PureComponent : React.Component;
+
+  class ReactMeteorData extends BaseComponent {
     getMeteorData() {
       return getMeteorData(this.props);
     }

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -14,5 +14,5 @@ export default function createContainer(options = {}, Component) {
     };
   }
 
-  return connect(expandedOptions, Component);
+  return connect(expandedOptions)(Component);
 }

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -13,6 +13,5 @@ export default function createContainer(options = {}, Component) {
     };
   }
 
-  const connected = connect(expandedOptions, Component);
-  return React.createElement(connected);
+  return connect(expandedOptions, Component);
 }

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -2,7 +2,6 @@
  * Container helper using react-meteor-data.
  */
 
-import createReactClass from 'create-react-class';
 import React from 'react';
 import { connect } from './ReactMeteorData.jsx';
 

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -3,9 +3,7 @@
  */
 
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
-
-import ReactMeteorData from './ReactMeteorData.jsx';
+import { connect } from './ReactMeteorData.jsx';
 
 export default function createContainer(options = {}, Component) {
   let expandedOptions = options;
@@ -15,25 +13,6 @@ export default function createContainer(options = {}, Component) {
     };
   }
 
-  const {
-    getMeteorData,
-    pure = true,
-  } = expandedOptions;
-
-  const mixins = [ReactMeteorData];
-  if (pure) {
-    mixins.push(PureRenderMixin);
-  }
-
-  /* eslint-disable react/prefer-es6-class */
-  return React.createClass({
-    displayName: 'MeteorDataContainer',
-    mixins,
-    getMeteorData() {
-      return getMeteorData(this.props);
-    },
-    render() {
-      return <Component {...this.props} {...this.data} />;
-    },
-  });
+  const connected = connect(expandedOptions, Component);
+  return React.createElement(connected);
 }

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'react-meteor-data',
-  summary: 'React mixin for reactively tracking Meteor data',
-  version: '0.2.10',
+  summary: 'React higher-order component for reactively tracking Meteor data',
+  version: '0.2.11',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages',
 });

--- a/packages/react-meteor-data/react-meteor-data.jsx
+++ b/packages/react-meteor-data/react-meteor-data.jsx
@@ -4,6 +4,4 @@ checkNpmVersions({
   react: '15.x',
 }, 'react-meteor-data');
 
-const createContainer = require('./createContainer.jsx').default;
-
-export { createContainer };
+export { default as createContainer } from './createContainer.jsx';

--- a/packages/react-meteor-data/react-meteor-data.jsx
+++ b/packages/react-meteor-data/react-meteor-data.jsx
@@ -1,10 +1,9 @@
 import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
+
 checkNpmVersions({
   react: '15.x',
-  'react-addons-pure-render-mixin': '15.x',
 }, 'react-meteor-data');
 
 const createContainer = require('./createContainer.jsx').default;
-const ReactMeteorData = require('./ReactMeteorData.jsx').default;
 
-export { createContainer, ReactMeteorData };
+export { createContainer };


### PR DESCRIPTION
Converts the ReactMeteorData mixin to a [Higher-Order Component](https://facebook.github.io/react/docs/higher-order-components.html)

This PR fixes warnings with latest React like:
* React.createClass is deprecated and will be removed in version 16.

Fixes #216
Closes #200 
(maybe more)