### PR TITLE
Switch to create-react-class

### DIFF
--- a/packages/react-meteor-data/README.md
+++ b/packages/react-meteor-data/README.md
@@ -10,10 +10,10 @@ To install the package, use `meteor add`:
 meteor add react-meteor-data
 ```
 
-You'll also need to install `react` and `react-addons-pure-render-mixin` if you have not already:
+You'll also need to install `react`, `create-react-class`, and `react-addons-pure-render-mixin` if you have not already:
 
 ```bash
-npm install --save react react-addons-pure-render-mixin
+npm install --save react create-react-class react-addons-pure-render-mixin
 ```
 
 ### Usage

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -2,7 +2,7 @@
  * Container helper using react-meteor-data.
  */
 
-import createClass from 'create-react-class';
+import createReactClass from 'create-react-class';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -27,7 +27,7 @@ export default function createContainer(options = {}, Component) {
   }
 
   /* eslint-disable react/prefer-es6-class */
-  return createClass({
+  return createReactClass({
     displayName: 'MeteorDataContainer',
     mixins,
     getMeteorData() {

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -2,6 +2,7 @@
  * Container helper using react-meteor-data.
  */
 
+import createClass from 'create-react-class';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -26,7 +27,7 @@ export default function createContainer(options = {}, Component) {
   }
 
   /* eslint-disable react/prefer-es6-class */
-  return React.createClass({
+  return createClass({
     displayName: 'MeteorDataContainer',
     mixins,
     getMeteorData() {

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React mixin for reactively tracking Meteor data',
-  version: '0.2.9',
+  version: '0.2.10',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages',
 });

--- a/packages/react-meteor-data/react-meteor-data.jsx
+++ b/packages/react-meteor-data/react-meteor-data.jsx
@@ -2,6 +2,7 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 checkNpmVersions({
   react: '15.x',
   'react-addons-pure-render-mixin': '15.x',
+  'create-react-class': '15.x',
 }, 'react-meteor-data');
 
 const createContainer = require('./createContainer.jsx').default;


### PR DESCRIPTION
React 15.5 has deprecated React.createClass. This fixes that. Prompted by [this issue](https://github.com/meteor/meteor/issues/8625)