### PR TITLE
Restored the ReactMeteorData object so it can still be used with mixins.

### DIFF
--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -1,4 +1,5 @@
 /* global Package */
+/* eslint-disable react/prefer-stateless-function */
 
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
@@ -158,9 +159,14 @@ export const ReactMeteorData = {
   },
 };
 
+class ReactComponent extends React.Component {}
+Object.assign(ReactComponent.prototype, ReactMeteorData);
+class ReactPureComponent extends React.PureComponent {}
+Object.assign(ReactPureComponent.prototype, ReactMeteorData);
+
 export function connect({ getMeteorData, pure = true }) {
-  const BaseComponent = pure ? React.PureComponent : React.Component;
-  return (WrappedComponent) => {
+  const BaseComponent = pure ? ReactPureComponent : ReactComponent;
+  return (WrappedComponent) => (
     class ReactMeteorDataComponent extends BaseComponent {
       getMeteorData() {
         return getMeteorData(this.props);
@@ -169,14 +175,5 @@ export function connect({ getMeteorData, pure = true }) {
         return <WrappedComponent {...this.props} {...this.data} />;
       }
     }
-
-    ReactMeteorDataComponent.prototype.componentWillMount =
-      ReactMeteorData.componentWillMount;
-    ReactMeteorDataComponent.prototype.componentWillUpdate =
-      ReactMeteorData.componentWillUpdate;
-    ReactMeteorDataComponent.prototype.componentWillUnmount =
-      ReactMeteorData.componentWillUnmount;
-
-    return ReactMeteorDataComponent;
-  };
+  );
 }

--- a/packages/react-meteor-data/react-meteor-data.jsx
+++ b/packages/react-meteor-data/react-meteor-data.jsx
@@ -5,3 +5,4 @@ checkNpmVersions({
 }, 'react-meteor-data');
 
 export { default as createContainer } from './createContainer.jsx';
+export { ReactMeteorData } from './ReactMeteorData.jsx';


### PR DESCRIPTION
This PR is intended to help resolve backwards compatibility issues that were introduced in PR #217, and will fix #223. The newer HOC approach is maintained with these changes, but the pre-existing `ReactMeteorData` object is preserved and exported, which allows people using mixin approaches to continue using the latest version of this package. 

We should probably consider releasing a beta version with these changes.