### PR TITLE
Remove react-addons-test-utils and use react-dom/test-utils

### DIFF
--- a/packages/react-runtime/react-runtime.js
+++ b/packages/react-runtime/react-runtime.js
@@ -14,7 +14,6 @@ const requiredPackages = {
 
 if (Meteor.isDevelopment) {
   _.extend(requiredPackages, {
-    'react-addons-test-utils': '15.x',
     'react-addons-perf': '15.x',
   });
 }
@@ -35,7 +34,7 @@ React.addons = {
 };
 
 if (Meteor.isDevelopment) {
-  React.addons.TestUtils = require('react-addons-test-utils');
+  React.addons.TestUtils = require('react-dom/test-utils');
   React.addons.Perf = require('react-addons-perf');
 }
 

--- a/tests/react-runtime-harness/.meteor/versions
+++ b/tests/react-runtime-harness/.meteor/versions
@@ -55,7 +55,7 @@ practicalmeteor:mocha-core@0.1.4
 practicalmeteor:sinon@1.14.1_2
 promise@0.6.5
 random@1.0.7
-react-runtime@15.0.0
+react-runtime@15.0.1
 reactive-dict@1.1.5
 reactive-var@1.0.7
 reload@1.1.6

--- a/tests/react-runtime-harness/package.json
+++ b/tests/react-runtime-harness/package.json
@@ -13,7 +13,6 @@
     "react-addons-linked-state-mixin": "^15.0.0",
     "react-addons-perf": "^15.0.0",
     "react-addons-pure-render-mixin": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
     "react-addons-transition-group": "^15.0.0",
     "react-addons-update": "^15.0.0",
     "react-dom": "^15.0.0"


### PR DESCRIPTION
This change fixes a deprecation warning present in every Meteor app using React.

At the moment, the error that results amounts to console noise, but it's easy to imagine `react-dom/test-utils` adding functionality while `react-addons-test-utils` will only stagnate.

I don't think this change would cause any problems for apps that depend on this package, but I'm happy to add safeguards if needed.