### PR TITLE
Update version range for React 15 & 16

### DIFF
--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React higher-order component for reactively tracking Meteor data',
-  version: '0.2.13',
+  version: '0.2.14',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages',
 });

--- a/packages/react-meteor-data/react-meteor-data.jsx
+++ b/packages/react-meteor-data/react-meteor-data.jsx
@@ -1,7 +1,7 @@
 import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 
 checkNpmVersions({
-  react: '15.x',
+  react: '15.3 - 16',
 }, 'react-meteor-data');
 
 export { default as createContainer } from './createContainer.jsx';


### PR DESCRIPTION
This PR updates the `checkNpmVersions` range for React to fix the

```
WARNING: npm peer requirements (for react-meteor-data) not installed:
 - react@16.0.0 installed, react@15.x needed
```

warning if React 16 is installed. I also updated the version range for React 15 (from 15.x to ^15.3) because 15.3.0 is the oldest version that works with `react-meteor-data`.

Fixes #214