### PR TITLE
feat(createContainer): allow function composition

### DIFF
--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -6,6 +6,9 @@ import React from 'react';
 import { connect } from './ReactMeteorData.jsx';
 
 export default function createContainer(options = {}, Component) {
+  // cheap curry
+  if (Component === undefined) return createContainer.bind(createContainer, options);
+
   let expandedOptions = options;
   if (typeof options === 'function') {
     expandedOptions = {

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -1,8 +1,6 @@
 /**
  * Container helper using react-meteor-data.
  */
-
-import React from 'react';
 import { connect } from './ReactMeteorData.jsx';
 
 export default function createContainer(options = {}, Component) {


### PR DESCRIPTION
## Problem

Currently, `createContainer` cannot be composed.  Composing HOCs is a very common need in the React community.

```jsx
compose(
  createContainer(() => { ... })),
  withJoyride(),
  ResponsiveComponent(),
)(MyComponent)
```

This cannot be accomplished because `createContainer` requires all arguments up front. We have to wrap it in order to compose it:

```jsx
compose(
  MyComponent => createContainer(() => { ... }, MyComponent),
  withJoyride(),
  ResponsiveComponent(),
)(MyComponent)
```

## Solution

This is solved by currying.  This PR adds cheap currying to `createContainer`.


When all arguments all passed, the function is called:
```js
const ContainerComponent = createContainer(() => { ... }, MyComponent)
```

When partial arguments are passed, a function is returned that accepts the remaining arguments:
```js
const awaitingComponent = createContainer(() => { ... })

const ContainerComponent = awaitingComponent(MyComponent)
```