### PR TITLE
add deprecation warning to createContainer

### DIFF
--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -164,7 +164,16 @@ Object.assign(ReactComponent.prototype, ReactMeteorData);
 class ReactPureComponent extends React.PureComponent {}
 Object.assign(ReactPureComponent.prototype, ReactMeteorData);
 
-export function connect({ getMeteorData, pure = true }) {
+export default function connect(options) {
+  let expandedOptions = options;
+  if (typeof options === 'function') {
+    expandedOptions = {
+      getMeteorData: options,
+    };
+  }
+
+  const { getMeteorData, pure = true } = expandedOptions;
+
   const BaseComponent = pure ? ReactPureComponent : ReactComponent;
   return (WrappedComponent) => (
     class ReactMeteorDataComponent extends BaseComponent {

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -3,15 +3,18 @@
  */
 
 import React from 'react';
-import { connect } from './ReactMeteorData.jsx';
+import connect from './ReactMeteorData.jsx';
 
-export default function createContainer(options = {}, Component) {
-  let expandedOptions = options;
-  if (typeof options === 'function') {
-    expandedOptions = {
-      getMeteorData: options,
-    };
+let hasDisplayedWarning = false;
+
+export default function createContainer(options, Component) {
+  if (!hasDisplayedWarning) {
+    console.warn(
+      'Warning: createContainer was deprecated in react-meteor-data@0.2.13. Use withTracker instead.\n' +
+        'https://github.com/meteor/react-packages/tree/devel/packages/react-meteor-data#usage',
+    );
+    hasDisplayedWarning = true;
   }
 
-  return connect(expandedOptions)(Component);
+  return connect(options)(Component);
 }

--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -2,13 +2,14 @@
  * Container helper using react-meteor-data.
  */
 
+import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import connect from './ReactMeteorData.jsx';
 
 let hasDisplayedWarning = false;
 
 export default function createContainer(options, Component) {
-  if (!hasDisplayedWarning) {
+  if (!hasDisplayedWarning && Meteor.isDevelopment) {
     console.warn(
       'Warning: createContainer was deprecated in react-meteor-data@0.2.13. Use withTracker instead.\n' +
         'https://github.com/meteor/react-packages/tree/devel/packages/react-meteor-data#usage',

--- a/packages/react-meteor-data/react-meteor-data.jsx
+++ b/packages/react-meteor-data/react-meteor-data.jsx
@@ -5,5 +5,5 @@ checkNpmVersions({
 }, 'react-meteor-data');
 
 export { default as createContainer } from './createContainer.jsx';
-export { default as withTracker } from './withTracker.jsx';
+export { default as withTracker } from './ReactMeteorData.jsx';
 export { ReactMeteorData } from './ReactMeteorData.jsx';

--- a/packages/react-meteor-data/withTracker.jsx
+++ b/packages/react-meteor-data/withTracker.jsx
@@ -1,5 +1,0 @@
-import createContainer from './createContainer';
-
-const withTracker = fn => C => createContainer(fn, C);
-
-export default withTracker;


### PR DESCRIPTION
Required a bit of refactoring. It makes much more sense to directly export the `connect` function as `withTracker`.