### PR TITLE
Adds a method to ReactMeteorDataComponent for retrieving the wrapped …

### DIFF
--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -180,6 +180,9 @@ export default function connect(options) {
       getMeteorData() {
         return getMeteorData(this.props);
       }
+			getWrappedComponent() {
+			  return WrappedComponent;
+			}
       render() {
         return <WrappedComponent {...this.props} {...this.data} />;
       }


### PR DESCRIPTION
…component.

This is useful if the parent component needs to call a method on the child. 