### PR TITLE
 Use Tracker.nonreactive when calling lifecycle methods of a React component from within a Tracker computation.

### DIFF
--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -76,7 +76,12 @@ class MeteorDataManager {
           c.stop();
           // Calling forceUpdate() triggers componentWillUpdate which
           // recalculates getMeteorData() and re-renders the component.
-          component.forceUpdate();
+          //
+          // Use Tracker.nonreactive so that autoruns, subscriptions, etc.
+          // created by the component don't get stopped when this computation is
+          // stopped, because the component is responsible for its own lifecycle
+          // and won't expect to have to recreate them.
+          Tracker.nonreactive(() => component.forceUpdate());
         }
       })
     ));

--- a/packages/react-template-helper/react-template-helper.js
+++ b/packages/react-template-helper/react-template-helper.js
@@ -46,7 +46,13 @@ Template.React.onRendered(function () {
     // End block of code to remove with Meteor 1.1.1
 
     var props = _.omit(data, 'component');
-    ReactDOM.render(React.createElement(comp, props), container);
+    // Don't stop autoruns, subscriptions, etc. created by the React component
+    // when something else invalidates the current computation, because the
+    // component is responsible for its own lifecycle and won't expect to have
+    // to recreate them.
+    Tracker.nonreactive(() => {
+      ReactDOM.render(React.createElement(comp, props), container);
+    });
   });
 });
 


### PR DESCRIPTION
This change fixes a problem seen in my Meteor app.  I'll be happy to provide a full reproduction on request, but I don't want to go to the trouble if the meteor/react-packages repository is as dead as it appears.