### PR TITLE
Add displayName

### DIFF
--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -175,7 +175,7 @@ export default function connect(options) {
   const { getMeteorData, pure = true } = expandedOptions;
 
   const BaseComponent = pure ? ReactPureComponent : ReactComponent;
-  return (WrappedComponent) => (
+  return (WrappedComponent) => {
     class ReactMeteorDataComponent extends BaseComponent {
       getMeteorData() {
         return getMeteorData(this.props);
@@ -184,5 +184,7 @@ export default function connect(options) {
         return <WrappedComponent {...this.props} {...this.data} />;
       }
     }
-  );
+    ReactMeteorDataComponent.displayName = 'withTracker(' + WrappedComponent.displayName + ')';
+    return ReactMeteorDataComponent;
+  };
 }

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React higher-order component for reactively tracking Meteor data',
-  version: '0.2.16',
+  version: '0.2.17',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages',
 });


### PR DESCRIPTION
Having a wrapped display name will make it easier to debug with React DevTools. Currently every wrapped component shows up as ReactMeteorDataComponent, which isn't very helpful. Now it will show up as `withTracker(SomeComponent)`