### PR TITLE
[WIP] Update lifecycle methods for newer React

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+\.idea/

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React higher-order component for reactively tracking Meteor data',
-  version: '0.2.16',
+  version: '0.2.17',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages',
 });


### PR DESCRIPTION
Starting on a fix for #252 and #256 (and maybe #242)
Sadly it isn't as easy as replacing it with the recommended new methods (in short that breaks everything).
Moving `componentWillMount` functionality to `constructor` fixes that part, but `componentWillUpdate` has no easy backward compatible solution. So at least I'm presenting here this half fix and hopefully I can figure out something later or someone else can finish what I started. :thinking: 