### PR TITLE
forward ref to the wrapped component

### DIFF
--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -175,14 +175,23 @@ export default function connect(options) {
   const { getMeteorData, pure = true } = expandedOptions;
 
   const BaseComponent = pure ? ReactPureComponent : ReactComponent;
-  return (WrappedComponent) => (
+
+  return (WrappedComponent) => {
     class ReactMeteorDataComponent extends BaseComponent {
       getMeteorData() {
-        return getMeteorData(this.props);
+        const { forwardedRef, ...props } = this.props;
+
+        return getMeteorData(props);
       }
+
       render() {
-        return <WrappedComponent {...this.props} {...this.data} />;
+        const { forwardedRef, ...props } = this.props;
+        return <WrappedComponent ref={forwardedRef} {...props} {...this.data} />;
       }
     }
-  );
+
+    return React.forwardRef((props, ref) => (
+      <ReactMeteorDataComponent {...props} forwardedRef={ref} />
+    ));
+  };
 }


### PR DESCRIPTION
Pass ref to the wrapped component.

This might be a breaking change as:

1. It requires at least React 16.3
2. Refs targeting `ReactMeteorDataComponent` itself now don't work anymore (I thought of something like `options.forwardRef` for this, but in our large project we do not have even one case where we had to reference `ReactMeteorDataComponent` itself, so I skipped it)

fixes https://github.com/meteor/react-packages/issues/202
fixes https://github.com/meteor/react-packages/issues/189
fixes https://github.com/meteor/react-packages/issues/162