### PR TITLE
Remove react-meteor-data's dependency on  check-npm-dependencies

### DIFF
--- a/packages/react-meteor-data/createContainer.jsx
+++ b/packages/react-meteor-data/createContainer.jsx
@@ -3,7 +3,6 @@
  */
 
 import { Meteor } from 'meteor/meteor';
-import React from 'react';
 import connect from './ReactMeteorData.jsx';
 
 let hasDisplayedWarning = false;

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -10,7 +10,6 @@ Package.onUse(function (api) {
   api.versionsFrom('1.3');
   api.use('tracker');
   api.use('ecmascript');
-  api.use('tmeasday:check-npm-versions@0.3.2');
 
   api.export(['ReactMeteorData']);
 

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React higher-order component for reactively tracking Meteor data',
-  version: '0.2.16',
+  version: '0.3.0',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages',
 });

--- a/packages/react-meteor-data/react-meteor-data.jsx
+++ b/packages/react-meteor-data/react-meteor-data.jsx
@@ -1,9 +1,3 @@
-import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
-
-checkNpmVersions({
-  react: '15.3 - 16',
-}, 'react-meteor-data');
-
 export { default as createContainer } from './createContainer.jsx';
 export { default as withTracker } from './ReactMeteorData.jsx';
 export { ReactMeteorData } from './ReactMeteorData.jsx';


### PR DESCRIPTION
Removes the dependency on [`tmeasday:check-npm-versions`](https://atmospherejs.com/tmeasday/check-npm-versions). This will save ~10kb in the bundle payload and save a small runtime cost.

An argument can be made that `check-npm-modules` doesn't provide much value when compared to what the Meteor build tool already does. Without this, Meteor will already display an error message
> Cannot find module 'react'

In my opinion, that is clear enough and the error provided by check-npm-versions doesn't provide much more insight - at least not enough to warrant the weight it adds to the production build. Furthermore, if you are using this package, it is very likely that you already have `react` installed; I can't imagine a developer getting very far without having `react` installed... at least not far enough to use `withTracker` in any capacity. 

Whilst it is nice to get this error at build time during development, I don't think the tradeoff is worth it, especially considering that it would only be helpful in very rare circumstances.