### PR TITLE
Rename deprecated lifecycle to support React 16.9

### DIFF
--- a/packages/react-meteor-data/ReactMeteorData.jsx
+++ b/packages/react-meteor-data/ReactMeteorData.jsx
@@ -124,14 +124,14 @@ class MeteorDataManager {
 }
 
 export const ReactMeteorData = {
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.data = {};
     this._meteorDataManager = new MeteorDataManager(this);
     const newData = this._meteorDataManager.calculateData();
     this._meteorDataManager.updateData(newData);
   },
 
-  componentWillUpdate(nextProps, nextState) {
+  UNSAFE_componentWillUpdate(nextProps, nextState) {
     const saveProps = this.props;
     const saveState = this.state;
     let newData;


### PR DESCRIPTION
This is just to suppress the warnings in React 16.9 that can greatly affect development. This is a stop-gap solution while waiting for the new withTracker/useTracker implementation in another PR