### PR TITLE
Make module lazy

### DIFF
--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -13,7 +13,7 @@ Package.onUse(function (api) {
   api.use('tracker');
   api.use('ecmascript');
 
-  api.mainModule('index.js');
+  api.mainModule('index.js', { lazy: true });
 });
 
 Package.onTest(function (api) {


### PR DESCRIPTION
Simply makes the main module [lazy](https://docs.meteor.com/packages/modules.html#Lazy-loading-modules-from-a-package).

Also closes #265