### PR TITLE
Make pure default to true like it used to - fix #287

### DIFF
--- a/packages/react-meteor-data/withTracker.tsx
+++ b/packages/react-meteor-data/withTracker.tsx
@@ -20,6 +20,8 @@ export default function withTracker(options: ReactiveFn | ReactiveOptions) {
       );
     });
 
-    return options.pure ? memo(WithTracker) : WithTracker;
-  };
+    // @ts-ignore
+    const { pure = true } = options;
+    return pure ? memo(WithTracker) : WithTracker;
+  }
 };


### PR DESCRIPTION
With the conversion TypeScript, I missed setting the default of pure to true in `withTracker`. This PR fixes it. Fixes issue #287.