### PR TITLE
Fix subscriptions not closed when stopping computation

### DIFF
--- a/packages/react-mongo/react-mongo.ts
+++ b/packages/react-mongo/react-mongo.ts
@@ -14,8 +14,8 @@ const useSubscriptionClient = (factory: () => Meteor.SubscriptionHandle, deps: D
   })
 
   useEffect(() => {
-    subscription.current = factory()
     const computation = Tracker.autorun(() => {
+      subscription.current = factory()
       if (subscription.current.ready()) forceUpdate()
     })
 


### PR DESCRIPTION
The subscription needs to be started within the `Tracker.autorun` context, otherwise it's not stopped when hook is cleaned up.