### PR TITLE
Include false in Typescript factory return definition

### DIFF
--- a/packages/react-mongo/README.md
+++ b/packages/react-mongo/README.md
@@ -18,7 +18,7 @@ Both methods accept a factory method, and deps.
 
 ## useSubscription(factory, deps)
 
-`useSubscription` takes a factory method, which should return a subscription handle, and a deps array. It can also return `void` to conditionally set up no subscription. The hook returns a subscription handle with a reactive `ready` method.
+`useSubscription` takes a factory method, which should return a subscription handle, and a deps array. It can also return `void` or `false` to conditionally set up no subscription. The hook returns a subscription handle with a reactive `ready` method.
 
 Invoking the `ready()` handle method will cause the hook to update react when the subscription becomes available.
 

--- a/packages/react-mongo/react-mongo.ts
+++ b/packages/react-mongo/react-mongo.ts
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useReducer, useRef, DependencyList } from 'react'
 const fur = (x: number): number => x + 1
 const useForceUpdate = () => useReducer(fur, 0)[1]
 
-const useSubscriptionClient = (factory: () => Meteor.SubscriptionHandle | void, deps: DependencyList= []) => {
+const useSubscriptionClient = (factory: () => Meteor.SubscriptionHandle | void | false, deps: DependencyList= []) => {
   const forceUpdate = useForceUpdate()
   const { current: refs } = useRef<{
     handle?: Meteor.SubscriptionHandle,
@@ -53,7 +53,7 @@ const useSubscriptionServer = (): Meteor.SubscriptionHandle => ({
   ready() { return true }
 })
 
-export const useSubscription = (factory: () => Meteor.SubscriptionHandle | void, deps: DependencyList = []) => (
+export const useSubscription = (factory: () => Meteor.SubscriptionHandle | void | false, deps: DependencyList = []) => (
   Meteor.isServer
     ? useSubscriptionServer()
     : useSubscriptionClient(factory, deps)

--- a/packages/react-mongo/types/react-mongo.d.ts
+++ b/packages/react-mongo/types/react-mongo.d.ts
@@ -5,6 +5,6 @@ declare type UseSubscriptionOptions = {
     deps?: DependencyList;
     updateOnReady?: boolean;
 };
-export declare const useSubscription: (factory: () => Meteor.SubscriptionHandle | void, deps?: DependencyList | UseSubscriptionOptions) => void;
+export declare const useSubscription: (factory: () => Meteor.SubscriptionHandle | void | false, deps?: DependencyList | UseSubscriptionOptions) => void;
 export declare const useCursor: <T = any>(factory: () => Mongo.Cursor<T>, deps?: DependencyList) => Mongo.Cursor<T>;
 export {};


### PR DESCRIPTION
May I suggest we add `false` as well? It already works (the code does a falsy check), and in some cases it allows for cleaner code — up to the user's preference of course:

```ts
useSubscription(() => boardId && Meteor.subscribe('board', boardId), [boardId])
```

You don't have to use it like this, but as the code allows it I see no reason for Typescript to give a warning. Hope you'll consider. Thanks!