### PR TITLE
Attempt to make the useSubscription hook simpler by removing reactivity

### DIFF
--- a/packages/react-mongo/react-mongo.ts
+++ b/packages/react-mongo/react-mongo.ts
@@ -33,6 +33,8 @@ const useSubscriptionClient = (
     const computation = Tracker.nonreactive(() => (
       Tracker.autorun(() => {
         subscription.current = Meteor.subscribe( name, ...args )
+        // @ts-ignore this is just an internal thing
+        subscription.current.deps = { name, args }
       })
     ))
 
@@ -41,7 +43,17 @@ const useSubscriptionClient = (
 
   return useCallback(
     () => {
-      return subscription.current?.ready()
+      if (subscription.current) {
+        // @ts-ignore
+        const { deps } = subscription.current
+        if (deps.name === name && deps.args === args) {
+          return subscription.current.ready()
+        } else {
+          // Prevented returning the previous subscription's status
+        }
+      }
+
+      return false
     },
     [name, ...args]
   )

--- a/packages/react-mongo/types/react-mongo.d.ts
+++ b/packages/react-mongo/types/react-mongo.d.ts
@@ -1,10 +1,9 @@
-import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { DependencyList } from 'react';
 declare type UseSubscriptionOptions = {
     deps?: DependencyList;
     updateOnReady?: boolean;
 };
-export declare const useSubscription: (factory: () => Meteor.SubscriptionHandle | void, deps?: DependencyList | UseSubscriptionOptions) => void;
+export declare const useSubscription: (name: string | false, args: any[]) => () => boolean;
 export declare const useCursor: <T = any>(factory: () => Mongo.Cursor<T>, deps?: DependencyList) => Mongo.Cursor<T>;
 export {};


### PR DESCRIPTION
This is a concept, work in progress based on @yched's comments [here](https://github.com/meteor/react-packages/pull/298#discussion_r516541716) and [here](https://github.com/meteor/react-packages/pull/298#discussion_r516519599).

This changes the `useSubscription` signature to match `Meteor.subscribe`. To be used as follows:

**Normal:**
```ts
const handle = useSubscription('board.projects', boardId)
```

**Conditional:**
```ts
const handle = useSubscription(!!boardId && 'board.projects', boardId)
```

This branch also contains a fix/workaround for the issue that the previous subscription's status is returned for one render after changing the arguments: e37ba55e0507ad1b80afd3fcfa6e3a551fe4d1a3.