### PR TITLE
Remove version  constraint on core typescirpt package

### DIFF
--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -9,10 +9,10 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom('1.12');
+  api.versionsFrom(['1.8.2', '1.12.0']);
   api.use('tracker');
   api.use('ecmascript');
-  api.use('typescript@4.1.2');
+  api.use('typescript');
 
   api.mainModule('index.js', ['client', 'server'], { lazy: true });
 });

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -9,7 +9,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom(['1.8.2', '1.12.0']);
+  api.versionsFrom(['1.8.2', '1.12.0', '2.0']);
   api.use('tracker');
   api.use('ecmascript');
   api.use('typescript');


### PR DESCRIPTION
We don't need to specify version constrains on core packages [when using `versionsFrom`.](https://docs.meteor.com/api/packagejs.html#PackageAPI-versionsFrom)

There is also nothing in this implementation that specifically requires the latest version of Meteor or the typescript package, so we should probably specify a range.