### PR TITLE
Only validate deps are an Array when provided

### DIFF
--- a/packages/react-meteor-data/useTracker.ts
+++ b/packages/react-meteor-data/useTracker.ts
@@ -154,7 +154,7 @@ const useTrackerDev = <T = any>(reactiveFn: IReactiveFn<T>, deps: DependencyList
       + `(reactiveFn), but got type of ${typeof reactiveFn}.`
     );
   }
-  if (!Array.isArray(deps)) {
+  if (deps && !Array.isArray(deps)) {
     console.warn(
       'Warning: useTracker expected an array in it\'s second argument '
       + `(dependency), but got type of ${typeof deps}.`


### PR DESCRIPTION
Fixes a regression in the dev mode input checks. `deps` should only be validated as an `Array` when they are provided. The hook allows for `deps` to be undefined.