### PR TITLE
Fix lost reactivity when using deps

### DIFF
--- a/packages/react-meteor-data/useTracker.tests.js
+++ b/packages/react-meteor-data/useTracker.tests.js
@@ -220,41 +220,6 @@ if (Meteor.isClient) {
     completed();
   });
 
-  Tinytest.addAsync('useTracker - basic track', async function (test, completed) {
-    var container = document.createElement("DIV");
-
-    var x = new ReactiveVar('aaa');
-
-    var Foo = () => {
-      const data = useTracker(() => {
-        return {
-          x: x.get()
-        };
-      }, []);
-      return <span>{data.x}</span>;
-    };
-
-    ReactDOM.render(<Foo/>, container);
-    test.equal(getInnerHtml(container), '<span>aaa</span>');
-
-    x.set('bbb');
-    await waitFor(() => {
-      Tracker.flush({_throwFirstError: true});
-    }, { container, timeout: 250 });
-
-    test.equal(getInnerHtml(container), '<span>bbb</span>');
-
-    test.equal(x._numListeners(), 1);
-
-    await waitFor(() => {
-      ReactDOM.unmountComponentAtNode(container);
-    }, { container, timeout: 250 });
-
-    test.equal(x._numListeners(), 0);
-
-    completed();
-  });
-
   // Make sure that calling ReactDOM.render() from an autorun doesn't
   // associate that autorun with the mixin's autorun.  When autoruns are
   // nested, invalidating the outer one stops the inner one, unless


### PR DESCRIPTION
This attempts to fix various lost reactivity reports, as well as some trouble with a particular "Maximum update depth exceeded" error, coming from (possibly) constantly updating `deps` interaction with `useEffect`, in two ways:

- Adds guards against containing computations effecting the enclosed computation in `useEffect`.
- Adds a system to keep the reference to `reactiveFn` always up to date with the latest render.

All tests are passing, but I'd like to see if we can work out a test to confirm the reported error.

#313