### PR TITLE
Add warning about setState within useTracker

### DIFF
--- a/packages/react-meteor-data/README.md
+++ b/packages/react-meteor-data/README.md
@@ -87,7 +87,7 @@ function Foo({ listId }) {
 "react-hooks/exhaustive-deps": ["warn", { "additionalHooks": "useTracker|useSomeOtherHook|..." }]
 ```
 
-**Warning:** It's best not to call React functions that may cause rerenders, such as the `setState` half of a `useState` hook, within `reactiveFn` (or other functions run with `Tracker.autorun`). Doing so can have unintended interactions, where a rerender (including effects in `useEffect`) may execute within a `Tracker`, causing them to invalidate when the original `useTracker` does.
+**Warning:** It's best not to call React functions that may cause rerenders, such as the `setState` half of a `useState` hook, within `reactiveFn` (or other functions run with `Tracker.autorun`). Doing so can have unintended interactions, where a rerender (including effects in `useEffect`) may execute within a `Tracker`, causing them to invalidate when the original `useTracker` does. Instead, return the relevant state from `useTracker` and apply React state changes within a `useLayoutEffect` or `useEffect` hook.
 
 #### `withTracker(reactiveFn)` higher-order component
 

--- a/packages/react-meteor-data/README.md
+++ b/packages/react-meteor-data/README.md
@@ -87,6 +87,8 @@ function Foo({ listId }) {
 "react-hooks/exhaustive-deps": ["warn", { "additionalHooks": "useTracker|useSomeOtherHook|..." }]
 ```
 
+**Warning:** It's best not to call React functions that may cause rerenders, such as the `setState` half of a `useState` hook, within `reactiveFn` (or other functions run with `Tracker.autorun`). Doing so can have unintended interactions, where a rerender (including effects in `useEffect`) may execute within a `Tracker`, causing them to invalidate when the original `useTracker` does.
+
 #### `withTracker(reactiveFn)` higher-order component
 
 You can use the `withTracker` HOC to wrap your components and pass them additional props values from a Tracker reactive function. The reactive function will get re-run whenever its reactive inputs change, and the wrapped component will re-render with the new values for the additional props.


### PR DESCRIPTION
One approach to resolving #317. Feel free to suggest rewording, or rewrite it yourself. It's a bit of a tricky issue to write...

I hesitate to say "don't mix React and Meteor state", because it *is* fine to set Meteor state (e.g. `Session.set`) within a React hook (e.g. `useEffect`).  It's just the other way around that seems problematic.