### PR TITLE
Fix data loss with immediate rerender, and add comparator argument

### DIFF
--- a/packages/react-meteor-data/package-lock.json
+++ b/packages/react-meteor-data/package-lock.json
@@ -54,9 +54,9 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.2.tgz",
-      "integrity": "sha512-+uWmsejEHfmSjyyM/LkrP0orfE2m5Mx9Xel4tXNeqi1ldK5XMQcDsFkBmLDtuyKUbxj2jGDo0H240fbCRJZo7Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
+      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
       "requires": {
         "@types/node": "*"
       }
@@ -67,9 +67,9 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/connect": {
-      "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -97,9 +97,9 @@
       }
     },
     "@types/meteor": {
-      "version": "1.4.42",
-      "resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-1.4.42.tgz",
-      "integrity": "sha512-gaYksL5mAhvEAgGYZyz1HOYTSZx4Fg3RG9yA3qSGi0bFbvut3lbTVORU7Ry2Z29n//ghgt+grxVmCIXBPjfcLw==",
+      "version": "1.4.66",
+      "resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-1.4.66.tgz",
+      "integrity": "sha512-gBKrGYqe3AFkP50eI2ELQa3Y7gjtjXEGEagUvcxTfhAf5LkHBzxm1FO9hBlVrJXyVYaoH5PDExaHMYgTwq+hcw==",
       "requires": {
         "@types/connect": "*",
         "@types/mongodb": "*",
@@ -108,18 +108,18 @@
       }
     },
     "@types/mongodb": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.5.5.tgz",
-      "integrity": "sha512-iIWBu740IPolqzpYUBdQs1T4LMiJv1CIIcJb6gX2mGtb/VmnFWONSiyUG+lJF4IUg+QEuIqpalW3eshiTCc8dQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-6YNqGP1hk5bjUFaim+QoFFuI61WjHiHE1BNeB41TA00Xd2K7zG4lcWyLLq/XtIp36uMavvS5hoAUJ+1u/GcX2Q==",
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
+      "version": "14.14.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -162,9 +162,9 @@
       }
     },
     "@types/underscore": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.4.tgz",
-      "integrity": "sha512-CjHWEMECc2/UxOZh0kpiz3lEyX2Px3rQS9HzD20lxMvx571ivOBQKeLnqEjxUY0BMgp6WJWo/pQLRBwMW5v4WQ=="
+      "version": "1.10.24",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.24.tgz",
+      "integrity": "sha512-T3NQD8hXNW2sRsSbLNjF/aBo18MyJlbw0lSpQHB/eZZtScPdexN4HSa8cByYwTw9Wy7KuOFr81mlDQcQQaZ79w=="
     },
     "@types/yargs": {
       "version": "15.0.4",

--- a/packages/react-meteor-data/package-lock.json
+++ b/packages/react-meteor-data/package-lock.json
@@ -239,6 +239,11 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.3.tgz",
       "integrity": "sha512-JZ8iPuEHDQzq6q0k7PKMGbrIdsgBB7TRrtVOUm4nSMCExlg5qQG4KXWTH2k90yggjM4tTumRGwTKJSldMzKyLA=="
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",

--- a/packages/react-meteor-data/package.json
+++ b/packages/react-meteor-data/package.json
@@ -1,11 +1,12 @@
 {
   "name": "react-meteor-data",
   "dependencies": {
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-test-renderer": "16.13.1",
     "@testing-library/react": "^10.0.2",
     "@types/meteor": "^1.4.66",
-    "@types/react": "^16.9.34"
+    "@types/react": "^16.9.34",
+    "fast-deep-equal": "^3.1.3",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "react-test-renderer": "16.13.1"
   }
 }

--- a/packages/react-meteor-data/package.json
+++ b/packages/react-meteor-data/package.json
@@ -5,7 +5,7 @@
     "react-dom": "16.13.1",
     "react-test-renderer": "16.13.1",
     "@testing-library/react": "^10.0.2",
-    "@types/meteor": "^1.4.42",
+    "@types/meteor": "^1.4.66",
     "@types/react": "^16.9.34"
   }
 }

--- a/packages/react-meteor-data/useTracker.tests.js
+++ b/packages/react-meteor-data/useTracker.tests.js
@@ -220,6 +220,41 @@ if (Meteor.isClient) {
     completed();
   });
 
+  Tinytest.addAsync('useTracker - basic track', async function (test, completed) {
+    var container = document.createElement("DIV");
+
+    var x = new ReactiveVar('aaa');
+
+    var Foo = () => {
+      const data = useTracker(() => {
+        return {
+          x: x.get()
+        };
+      }, []);
+      return <span>{data.x}</span>;
+    };
+
+    ReactDOM.render(<Foo/>, container);
+    test.equal(getInnerHtml(container), '<span>aaa</span>');
+
+    x.set('bbb');
+    await waitFor(() => {
+      Tracker.flush({_throwFirstError: true});
+    }, { container, timeout: 250 });
+
+    test.equal(getInnerHtml(container), '<span>bbb</span>');
+
+    test.equal(x._numListeners(), 1);
+
+    await waitFor(() => {
+      ReactDOM.unmountComponentAtNode(container);
+    }, { container, timeout: 250 });
+
+    test.equal(x._numListeners(), 0);
+
+    completed();
+  });
+
   // Make sure that calling ReactDOM.render() from an autorun doesn't
   // associate that autorun with the mixin's autorun.  When autoruns are
   // nested, invalidating the outer one stops the inner one, unless

--- a/packages/react-meteor-data/useTracker.ts
+++ b/packages/react-meteor-data/useTracker.ts
@@ -68,11 +68,7 @@ const useTrackerNoDeps = <T = any>(reactiveFn: IReactiveFn<T>, skipUpdate: ISkip
     refs.computation = c;
     if (c.firstRun) {
       // Always run the reactiveFn on firstRun
-      const data = reactiveFn(c);
-      if (Meteor.isDevelopment) {
-        checkCursor(data);
-      }
-      refs.trackerData = data;
+      refs.trackerData = reactiveFn(c);
     } else if (!skipUpdate || !skipUpdate(refs.trackerData, reactiveFn(c))) {
       // For any reactive change, forceUpdate and let the next render rebuild the computation.
       forceUpdate();
@@ -139,9 +135,6 @@ const useTrackerWithDeps = <T = any>(reactiveFn: IReactiveFn<T>, deps: Dependenc
     );
     // To avoid creating side effects in render, stop the computation immediately
     Meteor.defer(() => { comp.stop() });
-    if (Meteor.isDevelopment) {
-      checkCursor(refs.data);
-    }
   }, deps);
 
   useEffect(() => {
@@ -209,7 +202,9 @@ function useTrackerDev (reactiveFn, deps = null, skipUpdate = null) {
     }
   }
 
-  return useTracker(reactiveFn, deps, skipUpdate);
+  const data = useTracker(reactiveFn, deps, skipUpdate);
+  checkCursor(data);
+  return data;
 };
 
 export default Meteor.isDevelopment

--- a/packages/react-meteor-data/useTracker.ts
+++ b/packages/react-meteor-data/useTracker.ts
@@ -110,9 +110,14 @@ const useTrackerNoDeps = <T = any>(reactiveFn: IReactiveFn<T>, skipUpdate: ISkip
 
 const useTrackerWithDeps = <T = any>(reactiveFn: IReactiveFn<T>, deps: DependencyList, skipUpdate: ISkipUpdate<T> = null): T => {
   const [data, setData] = useState<T>();
-  const { current: refs } = useRef({ reactiveFn, data });
+  const { current: refs } = useRef({ reactiveFn, data, isMounted: false });
   refs.reactiveFn = reactiveFn;
-  refs.data = data;
+
+  // Only update refs.data when deps change, or the component is mounted.
+  // This prevents an unexpected value of `undefined` on immediate rerenders.
+  if (refs.isMounted) {
+    refs.data = data;
+  }
 
   useMemo(() => {
     // To jive with the lifecycle interplay between Tracker/Subscribe, run the
@@ -130,6 +135,7 @@ const useTrackerWithDeps = <T = any>(reactiveFn: IReactiveFn<T>, deps: Dependenc
   }, deps);
 
   useEffect(() => {
+    refs.isMounted = true;
     const computation = Tracker.nonreactive(
       () => Tracker.autorun((c) => {
         const data: T = refs.reactiveFn(c);

--- a/packages/react-meteor-data/withTracker.tsx
+++ b/packages/react-meteor-data/withTracker.tsx
@@ -5,6 +5,7 @@ type ReactiveFn = (props: object) => any;
 type ReactiveOptions = {
   getMeteorData: ReactiveFn;
   pure?: boolean;
+  skipUpdate?: (prev: any, next: any) => boolean;
 }
 
 export default function withTracker(options: ReactiveFn | ReactiveOptions) {
@@ -14,14 +15,16 @@ export default function withTracker(options: ReactiveFn | ReactiveOptions) {
       : options.getMeteorData;
 
     const WithTracker = forwardRef((props, ref) => {
-      const data = useTracker(() => getMeteorData(props) || {});
+      const data = useTracker(
+        () => getMeteorData(props) || {},
+        (options as ReactiveOptions).skipUpdate
+      );
       return (
         <Component ref={ref} {...props} {...data} />
       );
     });
 
-    // @ts-ignore
-    const { pure = true } = options;
+    const { pure = true } = options as ReactiveOptions;
     return pure ? memo(WithTracker) : WithTracker;
-  }
-};
+  };
+}


### PR DESCRIPTION
This adds a comparator argument as the 2nd or third argument.

It also fixes an issue that can occur when an immediate rerender occurs. This can happen when a state setter is called during render. In such cases, React immediately runs the rerender without additional lifecycle stages.

This PR contains tests and readme edits for everything.