### PR TITLE
feat(react-meteor-accounts): fixes types, deps; adds React check, loggingIn/Out sources, tests

### DIFF
--- a/packages/react-meteor-accounts/README.md
+++ b/packages/react-meteor-accounts/README.md
@@ -8,8 +8,14 @@ Simple hooks and higher-order components (HOCs) for getting reactive, stateful v
   - [Peer npm dependencies](#peer-npm-dependencies)
   - [Changelog](#changelog)
 - [Usage](#usage)
-  - [`useUser` / `withUser`](#useuser--withUser)
-  - [`useUserId` / `withUserId`](#useuserid--withUserId)
+  - [`useUser`](#useuser)
+  - [`useUserId`](#useuserid)
+  - [`useLoggingIn`](#useloggingin)
+  - [`useLoggingOut`](#useloggingout)
+  - [`withUser`](#withuser)
+  - [`withUserId`](#withuserid)
+  - [`withLoggingIn`](#withloggingin)
+  - [`withLoggingOut`](#withloggingout)
 
 ## Installation
 
@@ -39,32 +45,19 @@ Utilities for each data source are available for the two ways of writing React c
 
 _Note:_ All HOCs forward refs.
 
-### useUser() / withUser(...)
+### useUser()
 
-Get a stateful value of the current user record. Uses [`Meteor.user`](https://docs.meteor.com/api/accounts.html#Meteor-user), a reactive data source.
-
-The hook, `useUser()`, returns a stateful value of the current user record.
+Get a stateful value of the current user record. A hook. Uses [`Meteor.user`](https://docs.meteor.com/api/accounts.html#Meteor-user), a reactive data source.
 
 - Arguments: *none*.
 - Returns: `object | null`.
 
-The HOC, `withUser(Component)`, returns a wrapped version of `Component`, where `Component` receives a prop of the current user record, `user`.
-
-- Arguments:
-
-| Argument | Type | Required | Description |
-| --- | --- | --- | --- |
-| Component | `any` | yes | A React component. |
-
-- Returns: `React.ForwardRefExoticComponent`.
-
-Examples:
+Example:
 
 ```tsx
 import React from 'react';
-import { useUser, withUser } from 'meteor/react-meteor-accounts';
+import { useUser } from 'meteor/react-meteor-accounts';
 
-// Hook
 function Foo() {
   const user = useUser();
 
@@ -74,57 +67,27 @@ function Foo() {
 
   return <h1>Hello {user.username}</h1>;
 }
-
-// HOC
-class Bar extends React.Component {
-  render() {
-    if (this.props.user === null) {
-      return <h1>Log in</h1>;
-    }
-
-    return <h1>Hello {this.props.user.username}</h1>;
-  }
-}
-
-const WrappedBar = withUser(Bar);
 ```
 
-TypeScript signatures:
+TypeScript signature:
 
 ```ts
-// Hook
 function useUser(): Meteor.User | null;
-
-// HOC
-function withUser<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "user"> & Partial<WithUserProps>> & React.RefAttributes<unknown>>;
 ```
 
-### useUserId() / withUserId(...)
+### useUserId()
 
-Get a stateful value of the current user id. Uses [`Meteor.userId`](https://docs.meteor.com/api/accounts.html#Meteor-userId), a reactive data source.
-
-The hook, `useUserId()`, returns a stateful value of the current user id.
+Get a stateful value of the current user id. A hook. Uses [`Meteor.userId`](https://docs.meteor.com/api/accounts.html#Meteor-userId), a reactive data source. 
 
 - Arguments: *none*.
 - Returns: `string | null`.
 
-The HOC, `withUserId(Component)`, returns a wrapped version of `Component`, where `Component` receives a prop of the current user id, `userId`.
-
-- Arguments:
-
-| Argument | Type | Required | Description |
-| --- | --- | --- | --- |
-| Component | `React.ComponentType` | yes | A React component. |
-
-- Returns: `React.ForwardRefExoticComponent`.
-
-Examples:
+Example:
 
 ```tsx
 import React from 'react';
-import { useUserId, withUserId } from 'meteor/react-meteor-accounts';
+import { useUserId } from 'meteor/react-meteor-accounts';
 
-// Hook
 function Foo() {
   const userId = useUserId();
 
@@ -139,9 +102,134 @@ function Foo() {
     </div>
   );
 }
+```
 
-// HOC
-class Bar extends React.Component {
+TypeScript signature:
+
+```ts
+function useUserId(): string | null;
+```
+
+### useLoggingIn()
+
+Get a stateful value of whether a login method (e.g. `loginWith<Service>`) is currently in progress. A hook. Uses [`Meteor.loggingIn`](https://docs.meteor.com/api/accounts.html#Meteor-loggingIn), a reactive data source.
+
+- Arguments: *none*.
+- Returns: `boolean`.
+
+Example:
+
+```tsx
+import React from 'react';
+import { useLoggingIn } from 'meteor/react-meteor-accounts';
+
+function Foo() {
+  const loggingIn = useLoggingIn();
+
+  if (!loggingIn) {
+    return null;
+  }
+
+  return (
+    <div>Logging in, please wait a moment.</div>
+  );
+}
+```
+
+TypeScript signature:
+
+```ts
+function useLoggingIn(): boolean;
+```
+
+### useLoggingOut()
+
+Get a stateful value of whether the logout method is currently in progress. A hook. Uses `Meteor.loggingOut` (no online documentation), a reactive data source.
+
+- Arguments: *none*.
+- Returns: `boolean`.
+
+Example:
+
+```tsx
+import React from 'react';
+import { useLoggingOut } from 'meteor/react-meteor-accounts';
+
+function Foo() {
+  const loggingOut = useLoggingOut();
+
+  if (!loggingOut) {
+    return null;
+  }
+
+  return (
+    <div>Logging out, please wait a moment.</div>
+  );
+}
+```
+
+TypeScript signature:
+
+```ts
+function useLoggingOut(): boolean;
+```
+
+### withUser(...)
+
+Return a wrapped version of the given component, where the component receives a stateful prop of the current user record, `user`. A higher-order component. Uses [`Meteor.user`](https://docs.meteor.com/api/accounts.html#Meteor-user), a reactive data source. 
+
+- Arguments:
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| Component | `React.ComponentType` | yes | A React component. |
+
+- Returns: `React.ForwardRefExoticComponent`.
+
+Examples:
+
+```tsx
+import React from 'react';
+import { withUser } from 'meteor/react-meteor-accounts';
+
+class Foo extends React.Component {
+  render() {
+    if (this.props.user === null) {
+      return <h1>Log in</h1>;
+    }
+
+    return <h1>Hello {this.props.user.username}</h1>;
+  }
+}
+
+const FooWithUser = withUser(Foo);
+```
+
+TypeScript signature:
+
+```ts
+function withUser<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "user"> & Partial<WithUserProps>> & React.RefAttributes<unknown>>;
+```
+
+### withUserId(...)
+
+Return a wrapped version of the given component, where the component receives a stateful prop of the current user id. A higher-order component. Uses [`Meteor.userId`](https://docs.meteor.com/api/accounts.html#Meteor-userId), a reactive data source.
+
+- Arguments:
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| Component | `React.ComponentType` | yes | A React component. |
+
+- Returns: `React.ForwardRefExoticComponent`.
+
+Example:
+
+```tsx
+import React from 'react';
+import { withUserId } from 'meteor/react-meteor-accounts';
+
+class Foo extends React.Component {
   render() {
     return (
       <div>
@@ -156,29 +244,18 @@ class Bar extends React.Component {
   }
 }
 
-const WrappedBar = withUserId(Bar);
+const FooWithUserId = withUserId(Foo);
 ```
 
-TypeScript signatures:
+TypeScript signature:
 
 ```ts
-// Hook
-function useUserId(): string | null;
-
-// HOC
 function withUserId<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "userId"> & Partial<WithUserIdProps>> & React.RefAttributes<unknown>>;
 ```
 
-### useLoggingIn() / withLoggingIn(...)
+### withLoggingIn(...)
 
-Get a stateful value of whether a login method (e.g. `loginWith<Service>`) is currently in progress. Uses [`Meteor.loggingIn`](https://docs.meteor.com/api/accounts.html#Meteor-loggingIn), a reactive data source.
-
-The hook, `useLoggingIn()`, returns the stateful value.
-
-- Arguments: *none*.
-- Returns: `boolean`.
-
-The HOC, `withLoggingIn(Component)`, returns a wrapped version of `Component`, where `Component` receives a prop of the stateful value, `loggingIn`.
+Return a wrapped version of the given component, where the component receives a stateful prop of whether a login method (e.g. `loginWith<Service>`) is currently in progress. A higher-order component. Uses [`Meteor.loggingIn`](https://docs.meteor.com/api/accounts.html#Meteor-loggingIn), a reactive data source.
 
 - Arguments:
 
@@ -188,27 +265,13 @@ The HOC, `withLoggingIn(Component)`, returns a wrapped version of `Component`, w
 
 - Returns: `React.ForwardRefExoticComponent`.
 
-Examples:
+Example:
 
 ```tsx
 import React from 'react';
-import { useLoggingIn, withLoggingIn } from 'meteor/react-meteor-accounts';
+import { withLoggingIn } from 'meteor/react-meteor-accounts';
 
-// Hook
-function Foo() {
-  const loggingIn = useLoggingIn();
-
-  if (!loggingIn) {
-    return null;
-  }
-
-  return (
-    <div>Logging in, please wait a moment.</div>
-  );
-}
-
-// HOC
-class Bar extends React.Component {
+class Foo extends React.Component {
   render() {
     if (!this.props.loggingIn) {
       return null;
@@ -220,29 +283,18 @@ class Bar extends React.Component {
   }
 }
 
-const BarWithLoggingIn = withLoggingIn(Bar);
+const FooWithLoggingIn = withLoggingIn(Foo);
 ```
 
 TypeScript signatures:
 
 ```ts
-// Hook
-function useLoggingIn(): boolean;
-
-// HOC
 function withLoggingIn<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "loggingIn"> & Partial<WithLoggingInProps>> & React.RefAttributes<unknown>>;
 ```
 
-### useLoggingOut() / withLoggingOut(...)
+### withLoggingOut(...)
 
-Get a stateful value of whether the logout method is currently in progress. Uses `Meteor.loggingOut` (no online documentation), a reactive data source.
-
-The hook, `useLoggingOut()`, returns the stateful value.
-
-- Arguments: *none*.
-- Returns: `boolean`.
-
-The HOC, `withLoggingOut(Component)`, returns a wrapped version of `Component`, where `Component` receives a prop of the stateful value, `loggingOut`.
+Return a wrapped version of the given component, where the component receives a stateful prop of whether the logout method is currently in progress. A higher-order component. Uses `Meteor.loggingOut` (no online documentation), a reactive data source.
 
 - Arguments:
 
@@ -252,27 +304,13 @@ The HOC, `withLoggingOut(Component)`, returns a wrapped version of `Component`, 
 
 - Returns: `React.ForwardRefExoticComponent`.
 
-Examples:
+Example:
 
 ```tsx
 import React from 'react';
-import { useLoggingOut, withLoggingOut } from 'meteor/react-meteor-accounts';
+import { withLoggingOut } from 'meteor/react-meteor-accounts';
 
-// Hook
-function Foo() {
-  const loggingOut = useLoggingOut();
-
-  if (!loggingOut) {
-    return null;
-  }
-
-  return (
-    <div>Logging out in, please wait a moment.</div>
-  );
-}
-
-// HOC
-class Bar extends React.Component {
+class Foo extends React.Component {
   render() {
     if (!this.props.loggingOut) {
       return null;
@@ -284,15 +322,11 @@ class Bar extends React.Component {
   }
 }
 
-const BarWithLoggingOut = withLoggingOut(Bar);
+const FooWithLoggingOut = withLoggingOut(Foo);
 ```
 
-TypeScript signatures:
+TypeScript signature:
 
 ```ts
-// Hook
-function useLoggingOut(): boolean;
-
-// HOC
 function withLoggingOut<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "loggingOut"> & Partial<WithLoggingOutProps>> & React.RefAttributes<unknown>>;
 ```

--- a/packages/react-meteor-accounts/README.md
+++ b/packages/react-meteor-accounts/README.md
@@ -93,10 +93,10 @@ TypeScript signatures:
 
 ```ts
 // Hook
-const useUser: () => Meteor.User;
+function useUser(): Meteor.User | null;
 
 // HOC
-const withUser: (Component: any) => React.ForwardRefExoticComponent<React.RefAttributes<unknown>>;
+function withUser<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<unknown>>;
 ```
 
 ### useUserId() / withUserId(...)
@@ -106,7 +106,7 @@ Get a stateful value of the current user id from [`Meteor.userId`](https://docs.
 The hook, `useUserId()`, returns a stateful value of the current user id.
 
 - Arguments: *none*.
-- Returns: `string`.
+- Returns: `string | null`.
 
 The HOC, `withUserId(Component)`, returns a wrapped version of `Component`, where `Component` receives a prop of the current user id, `userId`.
 
@@ -114,7 +114,7 @@ The HOC, `withUserId(Component)`, returns a wrapped version of `Component`, wher
 
 | Argument | Type | Required | Description |
 | --- | --- | --- | --- |
-| Component | `any` | yes | A React component. |
+| Component | `React.ComponentType` | yes | A React component. |
 
 - Returns: `React.ForwardRefExoticComponent`.
 
@@ -163,8 +163,8 @@ TypeScript signatures:
 
 ```ts
 // Hook
-const useUserId: () => string;
+function useUserId(): string | null;
 
 // HOC
-const withUserId: (Component: any) => React.ForwardRefExoticComponent<React.RefAttributes<unknown>>;
+function withUserId<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<unknown>>;
 ```

--- a/packages/react-meteor-accounts/README.md
+++ b/packages/react-meteor-accounts/README.md
@@ -41,7 +41,7 @@ _Note:_ All HOCs forward refs.
 
 ### useUser() / withUser(...)
 
-Get a stateful value of the current user record from [`Meteor.user`](https://docs.meteor.com/api/accounts.html#Meteor-user), a reactive data source.
+Get a stateful value of the current user record. Uses [`Meteor.user`](https://docs.meteor.com/api/accounts.html#Meteor-user), a reactive data source.
 
 The hook, `useUser()`, returns a stateful value of the current user record.
 
@@ -96,12 +96,12 @@ TypeScript signatures:
 function useUser(): Meteor.User | null;
 
 // HOC
-function withUser<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<unknown>>;
+function withUser<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "user"> & Partial<WithUserProps>> & React.RefAttributes<unknown>>;
 ```
 
 ### useUserId() / withUserId(...)
 
-Get a stateful value of the current user id from [`Meteor.userId`](https://docs.meteor.com/api/accounts.html#Meteor-userId), a reactive data source.
+Get a stateful value of the current user id. Uses [`Meteor.userId`](https://docs.meteor.com/api/accounts.html#Meteor-userId), a reactive data source.
 
 The hook, `useUserId()`, returns a stateful value of the current user id.
 
@@ -166,5 +166,133 @@ TypeScript signatures:
 function useUserId(): string | null;
 
 // HOC
-function withUserId<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<unknown>>;
+function withUserId<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "userId"> & Partial<WithUserIdProps>> & React.RefAttributes<unknown>>;
+```
+
+### useLoggingIn() / withLoggingIn(...)
+
+Get a stateful value of whether a login method (e.g. `loginWith<Service>`) is currently in progress. Uses [`Meteor.loggingIn`](https://docs.meteor.com/api/accounts.html#Meteor-loggingIn), a reactive data source.
+
+The hook, `useLoggingIn()`, returns the stateful value.
+
+- Arguments: *none*.
+- Returns: `boolean`.
+
+The HOC, `withLoggingIn(Component)`, returns a wrapped version of `Component`, where `Component` receives a prop of the stateful value, `loggingIn`.
+
+- Arguments:
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| Component | `React.ComponentType` | yes | A React component. |
+
+- Returns: `React.ForwardRefExoticComponent`.
+
+Examples:
+
+```tsx
+import React from 'react';
+import { useLoggingIn, withLoggingIn } from 'meteor/react-meteor-accounts';
+
+// Hook
+function Foo() {
+  const loggingIn = useLoggingIn();
+
+  if (!loggingIn) {
+    return null;
+  }
+
+  return (
+    <div>Logging in, please wait a moment.</div>
+  );
+}
+
+// HOC
+class Bar extends React.Component {
+  render() {
+    if (!this.props.loggingIn) {
+      return null;
+    }
+
+    return (
+      <div>Logging in, please wait a moment.</div>
+    );
+  }
+}
+
+const BarWithLoggingIn = withLoggingIn(Bar);
+```
+
+TypeScript signatures:
+
+```ts
+// Hook
+function useLoggingIn(): boolean;
+
+// HOC
+function withLoggingIn<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "loggingIn"> & Partial<WithLoggingInProps>> & React.RefAttributes<unknown>>;
+```
+
+### useLoggingOut() / withLoggingOut(...)
+
+Get a stateful value of whether the logout method is currently in progress. Uses `Meteor.loggingOut` (no online documentation), a reactive data source.
+
+The hook, `useLoggingOut()`, returns the stateful value.
+
+- Arguments: *none*.
+- Returns: `boolean`.
+
+The HOC, `withLoggingOut(Component)`, returns a wrapped version of `Component`, where `Component` receives a prop of the stateful value, `loggingOut`.
+
+- Arguments:
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| Component | `React.ComponentType` | yes | A React component. |
+
+- Returns: `React.ForwardRefExoticComponent`.
+
+Examples:
+
+```tsx
+import React from 'react';
+import { useLoggingOut, withLoggingOut } from 'meteor/react-meteor-accounts';
+
+// Hook
+function Foo() {
+  const loggingOut = useLoggingOut();
+
+  if (!loggingOut) {
+    return null;
+  }
+
+  return (
+    <div>Logging out in, please wait a moment.</div>
+  );
+}
+
+// HOC
+class Bar extends React.Component {
+  render() {
+    if (!this.props.loggingOut) {
+      return null;
+    }
+
+    return (
+      <div>Logging out, please wait a moment.</div>
+    );
+  }
+}
+
+const BarWithLoggingOut = withLoggingOut(Bar);
+```
+
+TypeScript signatures:
+
+```ts
+// Hook
+function useLoggingOut(): boolean;
+
+// HOC
+function withLoggingOut<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "loggingOut"> & Partial<WithLoggingOutProps>> & React.RefAttributes<unknown>>;
 ```

--- a/packages/react-meteor-accounts/index.tests.ts
+++ b/packages/react-meteor-accounts/index.tests.ts
@@ -1,0 +1,1 @@
+import './react-accounts.tests.tsx';

--- a/packages/react-meteor-accounts/index.ts
+++ b/packages/react-meteor-accounts/index.ts
@@ -9,4 +9,13 @@ if (Meteor.isDevelopment) {
   }
 }
 
-export { useUser, withUser, useUserId, withUserId } from './react-accounts';
+export {
+  useUser,
+  useUserId,
+  useLoggingIn,
+  useLoggingOut,
+  withUser,
+  withUserId,
+  withLoggingIn,
+  withLoggingOut
+} from './react-accounts';

--- a/packages/react-meteor-accounts/index.ts
+++ b/packages/react-meteor-accounts/index.ts
@@ -1,0 +1,12 @@
+import { Meteor } from 'meteor/meteor';
+import React from 'react';
+
+if (Meteor.isDevelopment) {
+  // Custom check instead of `checkNpmVersions` to reduce prod bundle size (~8kb).
+  const v = React.version.split('.').map(val => parseInt(val));
+  if (v[0] < 16 || (v[0] === 16 && v[1] < 8)) {
+    console.warn('react-meteor-accounts requires React version >= 16.8.');
+  }
+}
+
+export { useUser, withUser, useUserId, withUserId } from './react-accounts';

--- a/packages/react-meteor-accounts/index.ts
+++ b/packages/react-meteor-accounts/index.ts
@@ -5,7 +5,7 @@ if (Meteor.isDevelopment) {
   // Custom check instead of `checkNpmVersions` to reduce prod bundle size (~8kb).
   const v = React.version.split('.').map(val => parseInt(val));
   if (v[0] < 16 || (v[0] === 16 && v[1] < 8)) {
-    console.warn('react-meteor-accounts requires React version >= 16.8.');
+    console.warn('react-accounts requires React version >= 16.8.');
   }
 }
 

--- a/packages/react-meteor-accounts/package-lock.json
+++ b/packages/react-meteor-accounts/package-lock.json
@@ -124,6 +124,12 @@
         }
       }
     },
+    "@tsconfig/recommended": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.1.tgz",
+      "integrity": "sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==",
+      "dev": true
+    },
     "@types/aria-query": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",

--- a/packages/react-meteor-accounts/package-lock.json
+++ b/packages/react-meteor-accounts/package-lock.json
@@ -100,6 +100,30 @@
         "@testing-library/dom": "^7.22.3"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@types/aria-query": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
@@ -190,6 +214,24 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
+      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/underscore": {
@@ -431,6 +473,26 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react-is": {

--- a/packages/react-meteor-accounts/package.js
+++ b/packages/react-meteor-accounts/package.js
@@ -13,5 +13,5 @@ Package.onUse((api) => {
 
   api.use(['accounts-base', 'tracker', 'typescript']);
 
-  api.mainModule('react-accounts.tsx', ['client', 'server'], { lazy: true });
+  api.mainModule('index.ts', ['client', 'server'], { lazy: true });
 });

--- a/packages/react-meteor-accounts/package.js
+++ b/packages/react-meteor-accounts/package.js
@@ -15,3 +15,16 @@ Package.onUse((api) => {
 
   api.mainModule('index.ts', ['client', 'server'], { lazy: true });
 });
+
+Package.onTest((api) => {
+  api.use([
+    'accounts-base',
+    'accounts-password',
+    'react-accounts',
+    'tinytest',
+    'tracker',
+    'typescript',
+  ]);
+
+  api.mainModule('index.tests.ts');
+});

--- a/packages/react-meteor-accounts/package.js
+++ b/packages/react-meteor-accounts/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   name: 'react-accounts',
-  summary: 'React hook for reactively tracking Meteor data',
+  summary: 'React hook for reactively tracking Meteor Accounts data',
   version: '1.0.0-beta.1',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages',

--- a/packages/react-meteor-accounts/package.js
+++ b/packages/react-meteor-accounts/package.js
@@ -20,7 +20,6 @@ Package.onTest((api) => {
   api.use([
     'accounts-base',
     'accounts-password',
-    'react-accounts',
     'tinytest',
     'tracker',
     'typescript',

--- a/packages/react-meteor-accounts/package.js
+++ b/packages/react-meteor-accounts/package.js
@@ -10,8 +10,8 @@ Package.describe({
 
 Package.onUse((api) => {
   api.versionsFrom(['1.10', '2.3']);
-  api.use('tracker');
-  api.use('typescript');
+
+  api.use(['accounts-base', 'tracker', 'typescript']);
 
   api.mainModule('react-accounts.tsx', ['client', 'server'], { lazy: true });
 });

--- a/packages/react-meteor-accounts/package.json
+++ b/packages/react-meteor-accounts/package.json
@@ -1,11 +1,12 @@
 {
   "name": "meteor-react-accounts",
   "scripts": {
-    "make-types": "npx typescript *.tsx --jsx preserve --declaration --emitDeclarationOnly --esModuleInterop --outDir types"
+    "make-types": "npx typescript react-accounts.tsx --jsx preserve --declaration --emitDeclarationOnly --esModuleInterop --outDir types --strict"
   },
   "devDependencies": {
     "@testing-library/react": "^10.0.2",
     "@testing-library/react-hooks": "^7.0.2",
+    "@tsconfig/recommended": "^1.0.1",
     "@types/meteor": "^1.4.42",
     "@types/react": "^16.9.34",
     "react": "16.13.1",

--- a/packages/react-meteor-accounts/package.json
+++ b/packages/react-meteor-accounts/package.json
@@ -5,6 +5,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^10.0.2",
+    "@testing-library/react-hooks": "^7.0.2",
     "@types/meteor": "^1.4.42",
     "@types/react": "^16.9.34",
     "react": "16.13.1",

--- a/packages/react-meteor-accounts/package.json
+++ b/packages/react-meteor-accounts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meteor-react-accounts",
   "scripts": {
-    "make-types": "npx typescript *.tsx --jsx preserve --declaration --emitDeclarationOnly --outDir types"
+    "make-types": "npx typescript *.tsx --jsx preserve --declaration --emitDeclarationOnly --esModuleInterop --outDir types"
   },
   "devDependencies": {
     "@testing-library/react": "^10.0.2",

--- a/packages/react-meteor-accounts/react-accounts.tests.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tests.tsx
@@ -127,4 +127,38 @@ if (Meteor.isClient) {
     test.isFalse(result.current);
     onComplete();
   });
+
+  Tinytest.addAsync('useLoggingOut - has initial value of `false`', async function (test, onComplete) {
+    await beforeEach();
+
+    const { result } = renderHook(() => useLoggingOut());
+
+    test.isFalse(result.current);
+    onComplete();
+  });
+  
+  Tinytest.addAsync('useLoggingOut - is reactive to logout starting', async function (test, onComplete) {
+    await beforeEach();
+
+    const { result, waitForNextUpdate } = renderHook(() => useLoggingOut());
+    logout();
+    // first update will be while logout is in progress
+    await waitForNextUpdate();
+
+    test.isTrue(result.current);
+    onComplete();
+  });
+  
+  Tinytest.addAsync('useLoggingOut - is reactive to logout finishing', async function (test, onComplete) {
+    await beforeEach();
+
+    const { result, waitForNextUpdate } = renderHook(() => useLoggingOut());
+    logout();
+    await waitForNextUpdate();
+    // second update will be after logout finishes
+    await waitForNextUpdate();
+
+    test.isFalse(result.current);
+    onComplete();
+  });
 }

--- a/packages/react-meteor-accounts/react-accounts.tests.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tests.tsx
@@ -1,0 +1,122 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { Accounts } from 'meteor/accounts-base';
+import { Meteor } from 'meteor/meteor';
+import { Tinytest } from 'meteor/tinytest';
+import { useLoggingIn, useLoggingOut, useUser, useUserId } from './react-accounts';
+
+// Prepare method for clearing DB (doesn't need to be isomorphic).
+if (Meteor.isServer) {
+  Meteor.methods({
+    reset() {
+      const res = Meteor.users.remove({});
+      console.log(`method - reset - ${res}`)
+      return res
+    },
+  });
+}
+
+if (Meteor.isClient) {
+  // fixture data
+  const username = 'username';
+  const password = 'password'; 
+  
+  // common test actions
+  async function login() {
+    console.log('before login');
+    await new Promise<void>((resolve, reject) => {
+        Meteor.loginWithPassword(username, password, (error) => {
+          if (error) reject(error);
+          else resolve();
+        })
+      })
+    console.log('after login');
+  }
+  async function logout() {
+    console.log('before logout');
+    await new Promise<void>((resolve, reject) => {
+      Meteor.logout((error) => {
+        if (error) reject(error);
+        else resolve();
+      })
+    })
+    console.log('after logout');
+  }
+  
+  // common test arrangements
+  async function beforeEach() {
+    console.log('before beforeEach');
+    console.log('beforeEach - before call reset');
+    // reset DB; must complete before creation to avoid potential overlap
+    await new Promise((resolve, reject) => {
+      Meteor.call('reset', (error, result) => {
+        console.log(`call - reset - ${result} - ${error}`)
+        if (error) reject(error);
+        else resolve(result);
+      })
+    });
+    console.log('beforeEach - after call reset');
+    // prepare sample user
+    console.log('beforeEach - before createUser');
+    await new Promise<void>((resolve, reject) => {
+      Accounts.createUser({ username, password }, (error) => {
+        if (error) reject(error);
+        else resolve();
+      })
+    });
+    console.log('beforeEach -before createUser');
+    // logout since `createUser` auto-logs-in
+    await logout();
+    console.log('after beforeEach');
+  }
+  async function afterEach() {
+    console.log('before afterEach');
+    await logout();
+    console.log('after afterEach');
+  }
+
+
+  // NOTE: each test body has three blocks: Arrange, Act, Assert.
+
+  Tinytest.addAsync('useUserId - has initial value of `null`', async function (test, onComplete) {
+    console.log('test - before - beforeEach');
+    try {
+      await beforeEach();
+    } catch (error) {
+      console.log('test - catch - beforeEach')
+      console.error(error)
+      throw error;
+    }
+    console.log('test - after - beforeEach');
+
+    const { result } = renderHook(() => useUserId());
+
+    test.isNull(result.current, 'Expect initial value to be `null`');
+    onComplete();
+  });
+
+  Tinytest.addAsync('useUserId - is reactive to login', async function (test, onComplete) {
+    await beforeEach();
+
+    const { result, waitForNextUpdate } = renderHook(() => useUserId());
+    // use `waitFor*` instead of `await`; mimics consumer usage
+    login();
+    await waitForNextUpdate();
+
+    test.isNotNull(result.current, 'Expect value after login to be not `null`')
+    onComplete();
+  });
+
+  
+  Tinytest.addAsync('useUserId - is reactive to logout', async function (test, onComplete) {
+    await beforeEach();
+    await login();
+
+    const { result, waitForNextUpdate } = renderHook(() => useUserId());
+    // use `waitFor*` instead of `await`; mimics consumer usage
+    logout();
+    await waitForNextUpdate();
+
+    test.isNull(result.current, 'Expect value after logout to be `null`')
+    onComplete();
+  });
+}

--- a/packages/react-meteor-accounts/react-accounts.tests.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tests.tsx
@@ -8,9 +8,7 @@ import { useLoggingIn, useLoggingOut, useUser, useUserId } from './react-account
 if (Meteor.isServer) {
   Meteor.methods({
     reset() {
-      const res = Meteor.users.remove({});
-      console.log(`method - reset - ${res}`)
-      return res
+      Meteor.users.remove({});
     },
   });
 }
@@ -159,6 +157,41 @@ if (Meteor.isClient) {
     await waitForNextUpdate();
 
     test.isFalse(result.current);
+    onComplete();
+  });
+  
+  Tinytest.addAsync('useUser - has initial value of `null`', async function (test, onComplete) {
+    await beforeEach();
+
+    const { result } = renderHook(() => useUser());
+
+    test.isNull(result.current);
+    onComplete();
+  });
+
+  Tinytest.addAsync('useUser - is reactive to login', async function (test, onComplete) {
+    await beforeEach();
+
+    const { result, waitForNextUpdate } = renderHook(() => useUser());
+    // use `waitFor*` instead of `await`; mimics consumer usage
+    login();
+    await waitForNextUpdate();
+
+    test.isNotNull(result.current)
+    test.equal(result.current.username, username, 'Expected username to match')
+    onComplete();
+  });
+
+  Tinytest.addAsync('useUser - is reactive to logout', async function (test, onComplete) {
+    await beforeEach();
+    await login();
+
+    const { result, waitForNextUpdate } = renderHook(() => useUser());
+    // use `waitFor*` instead of `await`; mimics consumer usage
+    logout();
+    await waitForNextUpdate();
+
+    test.isNull(result.current)
     onComplete();
   });
 }

--- a/packages/react-meteor-accounts/react-accounts.tests.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tests.tsx
@@ -1,8 +1,23 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
-import { Accounts } from 'meteor/accounts-base';
-import { Meteor } from 'meteor/meteor';
-import { Tinytest } from 'meteor/tinytest';
-import { useLoggingIn, useLoggingOut, useUser, useUserId } from './react-accounts';
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { Accounts } from "meteor/accounts-base";
+import { Meteor } from "meteor/meteor";
+import { Tinytest } from "meteor/tinytest";
+import React from "react";
+import {
+  useLoggingIn,
+  useLoggingOut,
+  useUser,
+  useUserId,
+  withLoggingIn,
+  WithLoggingInProps,
+  withLoggingOut,
+  WithLoggingOutProps,
+  withUser,
+  withUserId,
+  WithUserIdProps,
+  WithUserProps,
+} from "./react-accounts";
 
 // Prepare method for clearing DB (doesn't need to be isomorphic).
 if (Meteor.isServer) {
@@ -15,42 +30,42 @@ if (Meteor.isServer) {
 
 if (Meteor.isClient) {
   // fixture data
-  const username = 'username';
-  const password = 'password'; 
-  
+  const username = "username";
+  const password = "password";
+
   // common test actions
   async function login() {
     await new Promise<void>((resolve, reject) => {
       Meteor.loginWithPassword(username, password, (error) => {
         if (error) reject(error);
         else resolve();
-      })
-    })
+      });
+    });
   }
   async function logout() {
     await new Promise<void>((resolve, reject) => {
       Meteor.logout((error) => {
         if (error) reject(error);
         else resolve();
-      })
-    })
+      });
+    });
   }
-  
+
   // common test arrangements
   async function beforeEach() {
     // reset DB; must complete before creation to avoid potential overlap
     await new Promise((resolve, reject) => {
-      Meteor.call('reset', (error, result) => {
+      Meteor.call("reset", (error, result) => {
         if (error) reject(error);
         else resolve(result);
-      })
+      });
     });
     // prepare sample user
     await new Promise<void>((resolve, reject) => {
       Accounts.createUser({ username, password }, (error) => {
         if (error) reject(error);
         else resolve();
-      })
+      });
     });
     // logout since `createUser` auto-logs-in
     await logout();
@@ -58,140 +73,260 @@ if (Meteor.isClient) {
 
   // NOTE: each test body has three blocks: Arrange, Act, Assert.
 
-  Tinytest.addAsync('useUserId - has initial value of `null`', async function (test, onComplete) {
-    await beforeEach();
+  Tinytest.addAsync(
+    "Hooks - useUserId - has initial value of `null`",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    const { result } = renderHook(() => useUserId());
+      const { result } = renderHook(() => useUserId());
 
-    test.isNull(result.current);
-    onComplete();
-  });
+      test.isNull(result.current);
+      onComplete();
+    }
+  );
 
-  Tinytest.addAsync('useUserId - is reactive to login', async function (test, onComplete) {
-    await beforeEach();
+  Tinytest.addAsync(
+    "Hooks - useUserId - is reactive to login",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    const { result, waitForNextUpdate } = renderHook(() => useUserId());
-    // use `waitFor*` instead of `await`; mimics consumer usage
-    login();
-    await waitForNextUpdate();
+      const { result, waitForNextUpdate } = renderHook(() => useUserId());
+      // use `waitFor*` instead of `await`; mimics consumer usage
+      login();
+      await waitForNextUpdate();
 
-    test.isNotNull(result.current)
-    onComplete();
-  });
+      test.isNotNull(result.current);
+      onComplete();
+    }
+  );
 
-  Tinytest.addAsync('useUserId - is reactive to logout', async function (test, onComplete) {
-    await beforeEach();
-    await login();
+  Tinytest.addAsync(
+    "Hooks - useUserId - is reactive to logout",
+    async function (test, onComplete) {
+      await beforeEach();
+      await login();
 
-    const { result, waitForNextUpdate } = renderHook(() => useUserId());
-    // use `waitFor*` instead of `await`; mimics consumer usage
-    logout();
-    await waitForNextUpdate();
+      const { result, waitForNextUpdate } = renderHook(() => useUserId());
+      // use `waitFor*` instead of `await`; mimics consumer usage
+      logout();
+      await waitForNextUpdate();
 
-    test.isNull(result.current)
-    onComplete();
-  });
-  
-  Tinytest.addAsync('useLoggingIn - has initial value of `false`', async function (test, onComplete) {
-    await beforeEach();
+      test.isNull(result.current);
+      onComplete();
+    }
+  );
 
-    const { result } = renderHook(() => useLoggingIn());
+  Tinytest.addAsync(
+    "Hooks - useLoggingIn - has initial value of `false`",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    test.isFalse(result.current);
-    onComplete();
-  });
-  
-  Tinytest.addAsync('useLoggingIn - is reactive to login starting', async function (test, onComplete) {
-    await beforeEach();
+      const { result } = renderHook(() => useLoggingIn());
 
-    const { result, waitForNextUpdate } = renderHook(() => useLoggingIn());
-    login();
-    // first update will be while login strategy is in progress
-    await waitForNextUpdate();
+      test.isFalse(result.current);
+      onComplete();
+    }
+  );
 
-    test.isTrue(result.current);
-    onComplete();
-  });
-  
-  Tinytest.addAsync('useLoggingIn - is reactive to login finishing', async function (test, onComplete) {
-    await beforeEach();
+  Tinytest.addAsync(
+    "Hooks - useLoggingIn - is reactive to login starting",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    const { result, waitForNextUpdate } = renderHook(() => useLoggingIn());
-    login();
-    await waitForNextUpdate();
-    // second update will be after login strategy finishes
-    await waitForNextUpdate();
+      const { result, waitForNextUpdate } = renderHook(() => useLoggingIn());
+      login();
+      // first update will be while login strategy is in progress
+      await waitForNextUpdate();
 
-    test.isFalse(result.current);
-    onComplete();
-  });
+      test.isTrue(result.current);
+      onComplete();
+    }
+  );
 
-  Tinytest.addAsync('useLoggingOut - has initial value of `false`', async function (test, onComplete) {
-    await beforeEach();
+  Tinytest.addAsync(
+    "Hooks - useLoggingIn - is reactive to login finishing",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    const { result } = renderHook(() => useLoggingOut());
+      const { result, waitForNextUpdate } = renderHook(() => useLoggingIn());
+      login();
+      await waitForNextUpdate();
+      // second update will be after login strategy finishes
+      await waitForNextUpdate();
 
-    test.isFalse(result.current);
-    onComplete();
-  });
-  
-  Tinytest.addAsync('useLoggingOut - is reactive to logout starting', async function (test, onComplete) {
-    await beforeEach();
+      test.isFalse(result.current);
+      onComplete();
+    }
+  );
 
-    const { result, waitForNextUpdate } = renderHook(() => useLoggingOut());
-    logout();
-    // first update will be while logout is in progress
-    await waitForNextUpdate();
+  Tinytest.addAsync(
+    "Hooks - useLoggingOut - has initial value of `false`",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    test.isTrue(result.current);
-    onComplete();
-  });
-  
-  Tinytest.addAsync('useLoggingOut - is reactive to logout finishing', async function (test, onComplete) {
-    await beforeEach();
+      const { result } = renderHook(() => useLoggingOut());
 
-    const { result, waitForNextUpdate } = renderHook(() => useLoggingOut());
-    logout();
-    await waitForNextUpdate();
-    // second update will be after logout finishes
-    await waitForNextUpdate();
+      test.isFalse(result.current);
+      onComplete();
+    }
+  );
 
-    test.isFalse(result.current);
-    onComplete();
-  });
-  
-  Tinytest.addAsync('useUser - has initial value of `null`', async function (test, onComplete) {
-    await beforeEach();
+  Tinytest.addAsync(
+    "Hooks - useLoggingOut - is reactive to logout starting",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    const { result } = renderHook(() => useUser());
+      const { result, waitForNextUpdate } = renderHook(() => useLoggingOut());
+      logout();
+      // first update will be while logout is in progress
+      await waitForNextUpdate();
 
-    test.isNull(result.current);
-    onComplete();
-  });
+      test.isTrue(result.current);
+      onComplete();
+    }
+  );
 
-  Tinytest.addAsync('useUser - is reactive to login', async function (test, onComplete) {
-    await beforeEach();
+  Tinytest.addAsync(
+    "Hooks - useLoggingOut - is reactive to logout finishing",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    const { result, waitForNextUpdate } = renderHook(() => useUser());
-    // use `waitFor*` instead of `await`; mimics consumer usage
-    login();
-    await waitForNextUpdate();
+      const { result, waitForNextUpdate } = renderHook(() => useLoggingOut());
+      logout();
+      await waitForNextUpdate();
+      // second update will be after logout finishes
+      await waitForNextUpdate();
 
-    test.isNotNull(result.current)
-    test.equal(result.current.username, username, 'Expected username to match')
-    onComplete();
-  });
+      test.isFalse(result.current);
+      onComplete();
+    }
+  );
 
-  Tinytest.addAsync('useUser - is reactive to logout', async function (test, onComplete) {
-    await beforeEach();
-    await login();
+  Tinytest.addAsync(
+    "Hooks - useUser - has initial value of `null`",
+    async function (test, onComplete) {
+      await beforeEach();
 
-    const { result, waitForNextUpdate } = renderHook(() => useUser());
-    // use `waitFor*` instead of `await`; mimics consumer usage
-    logout();
-    await waitForNextUpdate();
+      const { result } = renderHook(() => useUser());
 
-    test.isNull(result.current)
-    onComplete();
-  });
+      test.isNull(result.current);
+      onComplete();
+    }
+  );
+
+  Tinytest.addAsync(
+    "Hooks - useUser - is reactive to login",
+    async function (test, onComplete) {
+      await beforeEach();
+
+      const { result, waitForNextUpdate } = renderHook(() => useUser());
+      // use `waitFor*` instead of `await`; mimics consumer usage
+      login();
+      await waitForNextUpdate();
+
+      test.isNotNull(result.current);
+      test.equal(
+        result.current.username,
+        username,
+        "Expected username to match"
+      );
+      onComplete();
+    }
+  );
+
+  Tinytest.addAsync(
+    "Hooks - useUser - is reactive to logout",
+    async function (test, onComplete) {
+      await beforeEach();
+      await login();
+
+      const { result, waitForNextUpdate } = renderHook(() => useUser());
+      // use `waitFor*` instead of `await`; mimics consumer usage
+      logout();
+      await waitForNextUpdate();
+
+      test.isNull(result.current);
+      onComplete();
+    }
+  );
+
+  // Since the HOCs wrap with hooks, the logic is already tested in 'Hooks' tests, and we only really need to test for prop forwarding. However, doing so for the "non-initial" case of all these values seems more prudent than just checking the default of `null` or `false`.
+
+  // :NOTE: these tests can be flaky (like 1 in 5 runs).
+
+  Tinytest.addAsync(
+    "HOCs - withUserId - forwards reactive value",
+    async function (test, onComplete) {
+      await beforeEach();
+      function Foo({ userId }: WithUserIdProps) {
+        // need something we can easily find; we don't know the id
+        return <span>{Boolean(userId).toString()}</span>;
+      }
+      const FooWithUserId = withUserId(Foo);
+      const { findByText } = render(<FooWithUserId />);
+
+      login();
+
+      await waitFor(() => findByText("true"));
+      cleanup();
+      onComplete();
+    }
+  );
+
+  // :TODO: this is flaky, fails ~1 in 10
+  Tinytest.addAsync(
+    "HOCs - withUser - forwards reactive value",
+    async function (test, onComplete) {
+      await beforeEach();
+      function Foo({ user }: WithUserProps) {
+        return <span>{user?.username || String(user)}</span>;
+      }
+      const FooWithUser = withUser(Foo);
+      const { findByText } = render(<FooWithUser />);
+
+      login();
+
+      await waitFor(() => findByText(username));
+      cleanup();
+      onComplete();
+    }
+  );
+
+  Tinytest.addAsync(
+    "HOCs - withLoggingIn - forwards reactive value",
+    async function (test, onComplete) {
+      await beforeEach();
+      function Foo({ loggingIn }: WithLoggingInProps) {
+        return <span>{loggingIn.toString()}</span>;
+      }
+      const FooWithLoggingIn = withLoggingIn(Foo);
+      const { findByText } = render(<FooWithLoggingIn />);
+
+      login();
+
+      await waitFor(() => findByText("true"));
+      cleanup();
+      onComplete();
+    }
+  );
+
+  // :TODO: this is flaky, fails ~1 in 5
+  Tinytest.addAsync(
+    "HOCs - withLoggingOut - forwards reactive value",
+    async function (test, onComplete) {
+      await beforeEach();
+      function Foo({ loggingOut }: WithLoggingOutProps) {
+        return <span>{loggingOut.toString()}</span>;
+      }
+      const FooWithLoggingOut = withLoggingOut(Foo);
+      const { findByText } = render(<FooWithLoggingOut />);
+      await login();
+
+      logout();
+
+      await waitFor(() => findByText("true"));
+      cleanup();
+      onComplete();
+    }
+  );
 }

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -13,7 +13,7 @@ declare module 'meteor/meteor' {
  * Hook to get a stateful value of the current user id. Uses `Meteor.userId`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
  */
-export function useUserId(): string | null {
+export function useUserId() {
   const [userId, setUserId] = useState(Meteor.userId())
   useEffect(() => {
     const computation = Tracker.autorun(() => {
@@ -55,7 +55,7 @@ export function withUserId<P>(Component: React.ComponentType<P>) {
  * Hook to get a stateful value of the current user record. Uses `Meteor.user`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-user
  */
-export function useUser(): Meteor.User | null {
+export function useUser() {
   const [user, setUser] = useState(Meteor.user());
   useEffect(() => {
     const computation = Tracker.autorun(() => {
@@ -74,7 +74,7 @@ export function useUser(): Meteor.User | null {
 }
 
 export interface WithUserProps {
-  user: Meteor.User | null;
+  user: Meteor.User;
 }
 
 /**

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -2,6 +2,10 @@ import { Meteor } from 'meteor/meteor'
 import { Tracker } from 'meteor/tracker'
 import React, { useState, useEffect, forwardRef } from 'react'
 
+/**
+ * Hook to get a stateful value of the current user id from `Meteor.userId`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
+ */
 export function useUserId(): string | null {
   const [userId, setUserId] = useState(Meteor.userId())
   useEffect(() => {
@@ -15,6 +19,10 @@ export function useUserId(): string | null {
   return userId
 }
 
+/**
+ * HOC to forward a stateful value of the current user id from `Meteor.userId`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
+ */
 export function withUserId<P>(Component: React.ComponentType<P>) {
   return forwardRef((props: P, ref) => {
     const userId = useUserId();
@@ -22,6 +30,10 @@ export function withUserId<P>(Component: React.ComponentType<P>) {
   })
 }
 
+/**
+ * Hook to get a stateful value of the current user record from `Meteor.user`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-user 
+ */
 export function useUser(): Meteor.User | null {
   const [user, setUser] = useState(Meteor.user())
   useEffect(() => {
@@ -35,6 +47,10 @@ export function useUser(): Meteor.User | null {
   return user
 }
 
+/**
+ * HOC to get a stateful value of the current user record from `Meteor.user`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-user 
+ */
 export function withUser<P>(Component: React.ComponentType<P>) {
   return forwardRef((props: P, ref) => {
     const user = useUser();

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -26,25 +26,37 @@ export function useUserId(): string | null {
   return userId
 }
 
+export interface WithUserIdProps {
+  userId: string | null;
+}
+
 /**
  * HOC to forward a stateful value of the current user id. Uses `Meteor.userId`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
  */
-export function withUserId<P extends {
-  userId: string | null
-}>(Component: React.ComponentType<P>) {
-  return forwardRef((props: P, ref) => {
-    const userId = useUserId();
-    return <Component userId={userId} ref={ref} {...props} />
-  })
+export function withUserId<P>(Component: React.ComponentType<P>) {
+  return forwardRef(
+    // Use `Omit` so instantiation doesn't require the prop. Union with `Partial` because prop should be optionally overridable / the wrapped component will be prepared for it anyways.
+    (props: Omit<P, keyof WithUserIdProps> & Partial<WithUserIdProps>, ref) => {
+      const userId = useUserId();
+      return (
+        <Component
+          // Cast because `P` may not include `userId`. TS forces cast to unknown first.
+          {...({ userId } as unknown as P)}
+          ref={ref}
+          {...props}
+        />
+      );
+    }
+  );
 }
 
 /**
  * Hook to get a stateful value of the current user record. Uses `Meteor.user`, a reactive data source.
- * @see https://docs.meteor.com/api/accounts.html#Meteor-user 
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-user
  */
 export function useUser(): Meteor.User | null {
-  const [user, setUser] = useState(Meteor.user())
+  const [user, setUser] = useState(Meteor.user());
   useEffect(() => {
     const computation = Tracker.autorun(() => {
       let user = Meteor.user();
@@ -52,26 +64,30 @@ export function useUser(): Meteor.User | null {
       if (user === undefined) {
         user = null;
       }
-      setUser(user)
-    })
+      setUser(user);
+    });
     return () => {
-      computation.stop()
-    }
-  }, [])
-  return user
+      computation.stop();
+    };
+  }, []);
+  return user;
+}
+
+export interface WithUserProps {
+  user: Meteor.User | null;
 }
 
 /**
  * HOC to get a stateful value of the current user record. Uses `Meteor.user`, a reactive data source.
- * @see https://docs.meteor.com/api/accounts.html#Meteor-user 
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-user
  */
-export function withUser<P extends {
-  user: Meteor.User | null
-}>(Component: React.ComponentType<P>) {
-  return forwardRef((props: P, ref) => {
-    const user = useUser();
-    return <Component user={user} ref={ref} {...props} />
-  })
+export function withUser<P>(Component: React.ComponentType<P>) {
+  return forwardRef(
+    (props: Omit<P, keyof WithUserProps> & Partial<WithUserProps>, ref) => {
+      const user = useUser();
+      return <Component {...({ user } as unknown as P)} ref={ref} {...props} />;
+    }
+  );
 }
 
 /**
@@ -79,55 +95,73 @@ export function withUser<P extends {
  * @see https://docs.meteor.com/api/accounts.html#Meteor-loggingIn
  */
 export function useLoggingIn(): boolean {
-  const [loggingIn, setLoggingIn] = useState(Meteor.loggingIn())
+  const [loggingIn, setLoggingIn] = useState(Meteor.loggingIn());
   useEffect(() => {
     const computation = Tracker.autorun(() => {
-      setLoggingIn(Meteor.loggingIn())
-    })
+      setLoggingIn(Meteor.loggingIn());
+    });
     return () => {
-      computation.stop()
-    }
-  }, [])
-  return loggingIn
+      computation.stop();
+    };
+  }, []);
+  return loggingIn;
+}
+
+export interface WithLoggingInProps {
+  loggingIn: boolean;
 }
 
 /**
  * HOC to forward a stateful value of whether a login method (e.g. `loginWith<Service>`) is currently in progress. Uses `Meteor.loggingIn`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-loggingIn
  */
-export function withLoggingIn<P extends {
-  loggingIn: boolean
-}>(Component: React.ComponentType<P>) {
-  return forwardRef((props: P, ref) => {
-    const loggingIn = useLoggingIn();
-    return <Component loggingIn={loggingIn} ref={ref} {...props} />
-  })
+export function withLoggingIn<P>(Component: React.ComponentType<P>) {
+  return forwardRef(
+    (
+      props: Omit<P, keyof WithLoggingInProps> & Partial<WithLoggingInProps>,
+      ref
+    ) => {
+      const loggingIn = useLoggingIn();
+      return (
+        <Component {...({ loggingIn } as unknown as P)} ref={ref} {...props} />
+      );
+    }
+  );
 }
 
 /**
  * Hook to get a stateful value of whether the logout method is currently in progress. Uses `Meteor.loggingOut`, a reactive data source.
  */
 export function useLoggingOut(): boolean {
-  const [loggingOut, setLoggingOut] = useState(Meteor.loggingOut())
+  const [loggingOut, setLoggingOut] = useState(Meteor.loggingOut());
   useEffect(() => {
     const computation = Tracker.autorun(() => {
-      setLoggingOut(Meteor.loggingOut())
-    })
+      setLoggingOut(Meteor.loggingOut());
+    });
     return () => {
-      computation.stop()
-    }
-  }, [])
-  return loggingOut
+      computation.stop();
+    };
+  }, []);
+  return loggingOut;
+}
+
+export interface WithLoggingOutProps {
+  loggingOut: boolean;
 }
 
 /**
  * HOC to forward a stateful value of whether the logout method is currently in progress. Uses `Meteor.loggingOut`, a reactive data source.
  */
-export function withLoggingOut<P extends {
-  loggingIn: boolean
-}>(Component: React.ComponentType<P>) {
-  return forwardRef((props: P, ref) => {
-    const loggingOut = useLoggingOut();
-    return <Component loggingOut={loggingOut} ref={ref} {...props} />
-  })
+export function withLoggingOut<P>(Component: React.ComponentType<P>) {
+  return forwardRef(
+    (
+      props: Omit<P, keyof WithLoggingOutProps> & Partial<WithLoggingOutProps>,
+      ref
+    ) => {
+      const loggingOut = useLoggingOut();
+      return (
+        <Component {...({ loggingOut } as unknown as P)} ref={ref} {...props} />
+      );
+    }
+  );
 }

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -2,13 +2,6 @@ import { Meteor } from 'meteor/meteor'
 import { Tracker } from 'meteor/tracker'
 import React, { useState, useEffect, forwardRef } from 'react'
 
-// Augmentation to add missing signature
-declare module 'meteor/meteor' {
-  module Meteor {
-    function loggingOut(): boolean;
-  }
-}
-
 /**
  * Hook to get a stateful value of the current user id. Uses `Meteor.userId`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
@@ -74,7 +67,7 @@ export function useUser() {
 }
 
 export interface WithUserProps {
-  user: Meteor.User;
+  user: Meteor.User | null;
 }
 
 /**

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -1,8 +1,8 @@
 import { Meteor } from 'meteor/meteor'
 import { Tracker } from 'meteor/tracker'
-import { useState, useEffect, forwardRef } from 'react'
+import React, { useState, useEffect, forwardRef } from 'react'
 
-export const useUserId = () => {
+export function useUserId(): string | null {
   const [userId, setUserId] = useState(Meteor.userId())
   useEffect(() => {
     const computation = Tracker.autorun(() => {
@@ -15,14 +15,14 @@ export const useUserId = () => {
   return userId
 }
 
-export const withUserId = (Component) => (
-  forwardRef((props, ref) => {
+export function withUserId<P>(Component: React.ComponentType<P>) {
+  return forwardRef((props: P, ref) => {
     const userId = useUserId();
     return <Component ref={ref} {...props} userId={userId} />
   })
-)
+}
 
-export const useUser = () => {
+export function useUser(): Meteor.User | null {
   const [user, setUser] = useState(Meteor.user())
   useEffect(() => {
     const computation = Tracker.autorun(() => {
@@ -35,9 +35,9 @@ export const useUser = () => {
   return user
 }
 
-export const withUser = (Component) => (
-  forwardRef((props, ref) => {
+export function withUser<P>(Component: React.ComponentType<P>) {
+  return forwardRef((props: P, ref) => {
     const user = useUser();
     return <Component ref={ref} {...props} user={user} />
   })
-)
+}

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -47,7 +47,12 @@ export function useUser(): Meteor.User | null {
   const [user, setUser] = useState(Meteor.user())
   useEffect(() => {
     const computation = Tracker.autorun(() => {
-      setUser(Meteor.user())
+      let user = Meteor.user();
+      // `Meteor.user` returns `undefined` after logout, but that ruins type signature and test parity. So, cast until that's fixed.
+      if (user === undefined) {
+        user = null;
+      }
+      setUser(user)
     })
     return () => {
       computation.stop()

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -23,7 +23,9 @@ export function useUserId(): string | null {
  * HOC to forward a stateful value of the current user id from `Meteor.userId`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
  */
-export function withUserId<P>(Component: React.ComponentType<P>) {
+export function withUserId<P extends {
+  userId: string | null
+}>(Component: React.ComponentType<P>) {
   return forwardRef((props: P, ref) => {
     const userId = useUserId();
     return <Component userId={userId} ref={ref} {...props} />
@@ -51,7 +53,9 @@ export function useUser(): Meteor.User | null {
  * HOC to get a stateful value of the current user record from `Meteor.user`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-user 
  */
-export function withUser<P>(Component: React.ComponentType<P>) {
+export function withUser<P extends {
+  user: Meteor.User | null
+}>(Component: React.ComponentType<P>) {
   return forwardRef((props: P, ref) => {
     const user = useUser();
     return <Component user={user} ref={ref} {...props} />

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -26,7 +26,7 @@ export function useUserId(): string | null {
 export function withUserId<P>(Component: React.ComponentType<P>) {
   return forwardRef((props: P, ref) => {
     const userId = useUserId();
-    return <Component ref={ref} {...props} userId={userId} />
+    return <Component userId={userId} ref={ref} {...props} />
   })
 }
 
@@ -54,6 +54,6 @@ export function useUser(): Meteor.User | null {
 export function withUser<P>(Component: React.ComponentType<P>) {
   return forwardRef((props: P, ref) => {
     const user = useUser();
-    return <Component ref={ref} {...props} user={user} />
+    return <Component user={user} ref={ref} {...props} />
   })
 }

--- a/packages/react-meteor-accounts/react-accounts.tsx
+++ b/packages/react-meteor-accounts/react-accounts.tsx
@@ -2,8 +2,15 @@ import { Meteor } from 'meteor/meteor'
 import { Tracker } from 'meteor/tracker'
 import React, { useState, useEffect, forwardRef } from 'react'
 
+// Augmentation to add missing signature
+declare module 'meteor/meteor' {
+  module Meteor {
+    function loggingOut(): boolean;
+  }
+}
+
 /**
- * Hook to get a stateful value of the current user id from `Meteor.userId`, a reactive data source.
+ * Hook to get a stateful value of the current user id. Uses `Meteor.userId`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
  */
 export function useUserId(): string | null {
@@ -20,7 +27,7 @@ export function useUserId(): string | null {
 }
 
 /**
- * HOC to forward a stateful value of the current user id from `Meteor.userId`, a reactive data source.
+ * HOC to forward a stateful value of the current user id. Uses `Meteor.userId`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
  */
 export function withUserId<P extends {
@@ -33,7 +40,7 @@ export function withUserId<P extends {
 }
 
 /**
- * Hook to get a stateful value of the current user record from `Meteor.user`, a reactive data source.
+ * Hook to get a stateful value of the current user record. Uses `Meteor.user`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-user 
  */
 export function useUser(): Meteor.User | null {
@@ -50,7 +57,7 @@ export function useUser(): Meteor.User | null {
 }
 
 /**
- * HOC to get a stateful value of the current user record from `Meteor.user`, a reactive data source.
+ * HOC to get a stateful value of the current user record. Uses `Meteor.user`, a reactive data source.
  * @see https://docs.meteor.com/api/accounts.html#Meteor-user 
  */
 export function withUser<P extends {
@@ -59,5 +66,63 @@ export function withUser<P extends {
   return forwardRef((props: P, ref) => {
     const user = useUser();
     return <Component user={user} ref={ref} {...props} />
+  })
+}
+
+/**
+ * Hook to get a stateful value of whether a login method (e.g. `loginWith<Service>`) is currently in progress. Uses `Meteor.loggingIn`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-loggingIn
+ */
+export function useLoggingIn(): boolean {
+  const [loggingIn, setLoggingIn] = useState(Meteor.loggingIn())
+  useEffect(() => {
+    const computation = Tracker.autorun(() => {
+      setLoggingIn(Meteor.loggingIn())
+    })
+    return () => {
+      computation.stop()
+    }
+  }, [])
+  return loggingIn
+}
+
+/**
+ * HOC to forward a stateful value of whether a login method (e.g. `loginWith<Service>`) is currently in progress. Uses `Meteor.loggingIn`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-loggingIn
+ */
+export function withLoggingIn<P extends {
+  loggingIn: boolean
+}>(Component: React.ComponentType<P>) {
+  return forwardRef((props: P, ref) => {
+    const loggingIn = useLoggingIn();
+    return <Component loggingIn={loggingIn} ref={ref} {...props} />
+  })
+}
+
+/**
+ * Hook to get a stateful value of whether the logout method is currently in progress. Uses `Meteor.loggingOut`, a reactive data source.
+ */
+export function useLoggingOut(): boolean {
+  const [loggingOut, setLoggingOut] = useState(Meteor.loggingOut())
+  useEffect(() => {
+    const computation = Tracker.autorun(() => {
+      setLoggingOut(Meteor.loggingOut())
+    })
+    return () => {
+      computation.stop()
+    }
+  }, [])
+  return loggingOut
+}
+
+/**
+ * HOC to forward a stateful value of whether the logout method is currently in progress. Uses `Meteor.loggingOut`, a reactive data source.
+ */
+export function withLoggingOut<P extends {
+  loggingIn: boolean
+}>(Component: React.ComponentType<P>) {
+  return forwardRef((props: P, ref) => {
+    const loggingOut = useLoggingOut();
+    return <Component loggingOut={loggingOut} ref={ref} {...props} />
   })
 }

--- a/packages/react-meteor-accounts/tsconfig.json
+++ b/packages/react-meteor-accounts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve"
+  }
+}

--- a/packages/react-meteor-accounts/types/react-accounts.d.ts
+++ b/packages/react-meteor-accounts/types/react-accounts.d.ts
@@ -1,6 +1,6 @@
-/// <reference types="react" />
 import { Meteor } from 'meteor/meteor';
-export declare const useUserId: () => string;
-export declare const withUserId: (Component: any) => import("react").ForwardRefExoticComponent<import("react").RefAttributes<unknown>>;
-export declare const useUser: () => Meteor.User;
-export declare const withUser: (Component: any) => import("react").ForwardRefExoticComponent<import("react").RefAttributes<unknown>>;
+import React from 'react';
+export declare function useUserId(): string | null;
+export declare function withUserId<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<unknown>>;
+export declare function useUser(): Meteor.User | null;
+export declare function withUser<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<unknown>>;

--- a/packages/react-meteor-accounts/types/react-accounts.d.ts
+++ b/packages/react-meteor-accounts/types/react-accounts.d.ts
@@ -1,6 +1,57 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
+declare module 'meteor/meteor' {
+    module Meteor {
+        function loggingOut(): boolean;
+    }
+}
+/**
+ * Hook to get a stateful value of the current user id. Uses `Meteor.userId`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
+ */
 export declare function useUserId(): string | null;
-export declare function withUserId<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<unknown>>;
+export interface WithUserIdProps {
+    userId: string | null;
+}
+/**
+ * HOC to forward a stateful value of the current user id. Uses `Meteor.userId`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-userId
+ */
+export declare function withUserId<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "userId"> & Partial<WithUserIdProps>> & React.RefAttributes<unknown>>;
+/**
+ * Hook to get a stateful value of the current user record. Uses `Meteor.user`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-user
+ */
 export declare function useUser(): Meteor.User | null;
-export declare function withUser<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<unknown>>;
+export interface WithUserProps {
+    user: Meteor.User | null;
+}
+/**
+ * HOC to get a stateful value of the current user record. Uses `Meteor.user`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-user
+ */
+export declare function withUser<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "user"> & Partial<WithUserProps>> & React.RefAttributes<unknown>>;
+/**
+ * Hook to get a stateful value of whether a login method (e.g. `loginWith<Service>`) is currently in progress. Uses `Meteor.loggingIn`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-loggingIn
+ */
+export declare function useLoggingIn(): boolean;
+export interface WithLoggingInProps {
+    loggingIn: boolean;
+}
+/**
+ * HOC to forward a stateful value of whether a login method (e.g. `loginWith<Service>`) is currently in progress. Uses `Meteor.loggingIn`, a reactive data source.
+ * @see https://docs.meteor.com/api/accounts.html#Meteor-loggingIn
+ */
+export declare function withLoggingIn<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "loggingIn"> & Partial<WithLoggingInProps>> & React.RefAttributes<unknown>>;
+/**
+ * Hook to get a stateful value of whether the logout method is currently in progress. Uses `Meteor.loggingOut`, a reactive data source.
+ */
+export declare function useLoggingOut(): boolean;
+export interface WithLoggingOutProps {
+    loggingOut: boolean;
+}
+/**
+ * HOC to forward a stateful value of whether the logout method is currently in progress. Uses `Meteor.loggingOut`, a reactive data source.
+ */
+export declare function withLoggingOut<P>(Component: React.ComponentType<P>): React.ForwardRefExoticComponent<React.PropsWithoutRef<Omit<P, "loggingOut"> & Partial<WithLoggingOutProps>> & React.RefAttributes<unknown>>;


### PR DESCRIPTION
Apologies for a large PR. I can split it up if needed.

Accomplished tasks:

- Added dependency on `"accounts-base"`.
  - Otherwise, the properties used would not exist on `Meteor.*`.
  - **Edit: I believe this is good reason to switch to using `Accounts.*` instead, but that's also trivial.**
- Corrected TS function signatures.
  - HOCs are apparently hard to type! but I looked around at some other major react packages and did what I thought was reasonable and works as demonstrated in the tests.
  - ~_side note:_ TS wrongly excludes `null` from the returns types of `Meteor.userId` / `Meteor.user`, not sure why... but that's why the corresponding hooks have explicit signatures~ **Edit: Solved**
  - Ran the types script again; updated the README
- Added check for at least React v16.8
- Added JSDoc function summaries
- Added hooks/HOCs for `Meteor.loggingIn`, `Meteor.loggingOut`
  - ~Turns out `Meteor.loggingOut` isn't declared in `@types/meteor` (or in the online docs for that matter), but it _does_ exist and it _is_ useful -- hence the TS module augmentation.~ **Edit: Solved**
  - Added respective docs to README
- Reorganized README to document each utility in isolation.
- Added tests for all exports.
  - Since HOCs are really just hooks, I tested all edges of reactivity in hook tests, and then just significant pass-through in hoc tests.
  - Two of the HOC tests are flaky -- i have no clue why. I spent a good amount of time debugging, but everything appeared to be running and finishing in order, but the values just wouldn't update one time out of ten... Doesn't make sense to me.

Outstanding tasks:

- [ ] Clarify package name: directory is `react-meteor-accounts` but `package.js` says `react-accounts`. 
    - other options i see: `"meteor/react-meteor-accounts"`, `react-trackers-accounts`, `react-accounts-trackers`. I'll leave up to maintainers.
- [ ] `use/withUser` should implementation `([options])` for optional field projection, like `Meteor.user`.
    - I think this is best to leave to another PR, where `useTracker` or `useFind` is brought in with `react-meteor-accounts` as a dep. 

Further considerations:

- I think it's best if HOCs were not contained in this package. Given that the package's minimum version guarantees React hooks, the consumer can easily compose their own HOC; this is what `react-router` advises [if `withRouter` is needed by v6 consumers](https://github.com/remix-run/react-router/blob/5730e28a7472e3a1b967d95c5c4cc643c570d5c7/docs/faq.md#what-happened-to-withrouter-i-need-it). This has an additional benefit: consider a consumer needs a combination of these HOCs. They must compose that combination of our HOCs. This can be unwieldly if they need all 4, and can be suboptimal to call `forwardRef` four times.
  - Another option is we exported a single HOC with all four sources, but then it's reactive to all four even when the user may not want that.
  - I think the solution is we simply shouldn't export HOC's, and instead adopt advice like `react-router`. This establishes better patterns for consumers and eases our implementation and testing burden.