### PR TITLE
adds fetchAsync to useFindServer

### DIFF
--- a/packages/react-meteor-data/useFind.ts
+++ b/packages/react-meteor-data/useFind.ts
@@ -54,7 +54,7 @@ const checkCursor = <T>(cursor: Mongo.Cursor<T> | Partial<{ _mongo: any, _cursor
       !(cursor._mongo && cursor._cursorDescription)) {
     console.warn(
       'Warning: useFind requires an instance of Mongo.Cursor. '
-      + 'Make sure you do NOT call .fetch() on your cursor.'
+      + 'Make sure you do NOT call .fetch() or .fetchAsync() on your cursor.'
     );
   }
 }

--- a/packages/react-meteor-data/useFind.ts
+++ b/packages/react-meteor-data/useFind.ts
@@ -129,6 +129,11 @@ const useFindServer = <T = any>(factory: () => Mongo.Cursor<T> | undefined | nul
   Tracker.nonreactive(() => {
     const cursor = factory()
     if (Meteor.isDevelopment) checkCursor(cursor)
+
+    if (cursor?.fetchAsync) {
+      return cursor.fetchAsync()
+    }
+
     return cursor?.fetch?.() ?? null
   })
 )


### PR DESCRIPTION
Considering that Meteor release 2.8 is bringing a new MongoDB Async API ([PR 12028](https://github.com/meteor/meteor/pull/12028)), this PR introduces `fetchAsync` method on `useFind` hook.

As recommended we should be using async methods on the server whenever possible to avoid future deprecation when fibers were removed. ([Discussion 11505](https://github.com/meteor/meteor/discussions/11505 ))
