### PR TITLE
fix(PeerDeps): Fixes peerDependencies after upgrading to support react 18

### DIFF
--- a/packages/react-template-helper/react-template-helper.js
+++ b/packages/react-template-helper/react-template-helper.js
@@ -1,7 +1,7 @@
 import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 checkNpmVersions({
-  'react': '15.3 - 17',
-  'react-dom': '15.3 - 17'
+  'react': '15.3 - 18',
+  'react-dom': '15.3 - 18'
 }, 'react-template-helper');
 
 const React = require('react');


### PR DESCRIPTION
Fixes:

```
WARNING: npm peer requirements (for react-template-helper) not installed:
   - react@18.2.0 installed, react@15.3 - 17 needed
 - react-dom@18.2.0 installed, react-dom@15.3 - 17 needed

  Read more about installing npm peer dependencies:
    http://guide.meteor.com/using-packages.html#peer-npm-dependencies
```