### PR TITLE
Fix useFind if cursor has no value

### DIFF
--- a/packages/react-meteor-data/useFind.ts
+++ b/packages/react-meteor-data/useFind.ts
@@ -99,16 +99,20 @@ const useFindClient = <T = any>(factory: () => (Mongo.Cursor<T> | undefined | nu
   const didMount = useRef(false)
 
   useEffect(() => {
-    if (!(cursor instanceof Mongo.Cursor)) {
-      return
-    }
-
     // Fetch intitial data if cursor was changed.
     if (didMount.current) {
+      if (!(cursor instanceof Mongo.Cursor)) {
+        return
+      }
+
       const data = fetchData(cursor)
       dispatch({ type: 'refresh', data })
     } else {
       didMount.current = true
+    }
+
+    if (!(cursor instanceof Mongo.Cursor)) {
+      return
     }
 
     const observer = cursor.observe({
@@ -133,7 +137,7 @@ const useFindClient = <T = any>(factory: () => (Mongo.Cursor<T> | undefined | nu
     }
   }, [cursor])
 
-  return data
+  return cursor ? data : cursor
 }
 
 const useFindServer = <T = any>(factory: () => Mongo.Cursor<T> | undefined | null, deps: DependencyList) => (


### PR DESCRIPTION
I fixed the behavior of `useFind` to pass a test in a `useFind.tests.js`.

```js
const docs = useFind(() => returnNull ? null : TestDocs.find(), [returnNull])
```

1. `useFind` can accept `() => null` as argument. Previously it returned `null` in this scenario, so I changed the return statement because it was returning an empty array.

2. I also added setting the `didMount` flag before checking if the cursor is `null` or `undefined`. Without this, example above will return an empty array if `returnNull` will change to `false`