### PR TITLE
Add types for react-meteor-data package

### DIFF
--- a/packages/react-meteor-data/package-types.json
+++ b/packages/react-meteor-data/package-types.json
@@ -1,0 +1,3 @@
+{
+  "typesEntry": "react-meteor-data.d.ts"
+}

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -13,6 +13,7 @@ Package.onUse((api) => {
   api.use('tracker');
   api.use('ecmascript');
   api.use('typescript');
+  api.addAssets('react-meteor-data.d.ts', 'server');
 
   api.mainModule('index.js', ['client', 'server'], { lazy: true });
 });

--- a/packages/react-meteor-data/react-meteor-data.d.ts
+++ b/packages/react-meteor-data/react-meteor-data.d.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Mongo } from 'meteor/mongo';
+
+export function useTracker<TDataProps>(reactiveFn: () => TDataProps): TDataProps
+export function useTracker<TDataProps>(reactiveFn: () => TDataProps, deps: React.DependencyList): TDataProps;
+export function useTracker<TDataProps>(
+  getMeteorData: () => TDataProps,
+  deps: React.DependencyList,
+  skipUpdate?: (prev: TDataProps, next: TDataProps) => boolean
+): TDataProps;
+export function useTracker<TDataProps>(
+  getMeteorData: () => TDataProps,
+  skipUpdate: (prev: TDataProps, next: TDataProps) => boolean
+): TDataProps;
+
+export function withTracker<TDataProps, TOwnProps>(
+  reactiveFn: (props: TOwnProps) => TDataProps
+): (reactComponent: React.ComponentType<TOwnProps & TDataProps>) => React.ComponentClass<TOwnProps>;
+export function withTracker<TDataProps, TOwnProps>(options: {
+  getMeteorData: (props: TOwnProps) => TDataProps;
+  pure?: boolean | undefined;
+  skipUpdate?: (prev: TDataProps, next: TDataProps) => boolean;
+}): (reactComponent: React.ComponentType<TOwnProps & TDataProps>) => React.ComponentClass<TOwnProps>;
+
+export function useSubscribe(name?: string, ...args: any[]): () => boolean;
+
+export function useFind<T>(factory: () => Mongo.Cursor<T>, deps?: React.DependencyList): T[];
+export function useFind<T>(factory: () => Mongo.Cursor<T> | undefined | null, deps?: React.DependencyList): T[] | null;


### PR DESCRIPTION
Types are taken from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/meteor/react-meteor-data.d.ts and updated to match the latest release.