### PR TITLE
Remove duplicate copy of react-meteor-data.d.ts from isopack

### DIFF
--- a/packages/react-meteor-data/package-types.json
+++ b/packages/react-meteor-data/package-types.json
@@ -1,3 +1,0 @@
-{
-  "typesEntry": "react-meteor-data.d.ts"
-}

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -13,7 +13,6 @@ Package.onUse((api) => {
   api.use('tracker');
   api.use('ecmascript');
   api.use('typescript');
-  api.addAssets('react-meteor-data.d.ts', 'server');
 
   api.mainModule('index.js', ['client', 'server'], { lazy: true });
 });


### PR DESCRIPTION
This is a followup to #377 based on my best understanding of how `zodern:types` expects type declarations to appear.

(FYI @zodern @piotrpospiech @radekmie in case any of y'all see something I've missed)

As discussed on #377, the current configuration does not seem to allow `zodern:types` to detect the type declarations for `react-meteor-data`. As I understand it, the current configuration doesn't work is because `react-meteor-data.d.ts` is being included as both an asset and as a source file. You can see this by looking at `~/.meteor/packages/react-meteor-data/2.6.2/os.json` (and similarly the files for `web.browser.json` and `web.browser.legacy.json`). This is because, in addition to explicitly including the definition file as an asset, the `typescript` package includes any `.ts` file (`.d.ts` or not).

When consuming types from Meteor packages, `zodern:types` [looks for `.d.ts` files](https://github.com/zodern/meteor-types/blob/85af3bb44dba2f8603804cc783146c627805cf44/types-entry.js#L97-L99) and uses them to provide types for the package, but only [if there's a *single* `.d.ts` file](https://github.com/zodern/meteor-types/blob/85af3bb44dba2f8603804cc783146c627805cf44/types-entry.js#L54-L57). While it deduplicates by the hash of definition files, the `react-meteor-data` package in Atmosphere does not seem to include the hash property for the asset version of the definition file, meaning it isn't deduped against the source versions. This means that `zodern:types` sees 2 different definition files in the package, and skips over it as being ambiguous.

We can fix this by not shipping the asset version of the definition file (since the non-asset version is already included). We also can drop the `package-types.json` file, which was never included in the resulting build and was thus vestigial.

I was able to test this locally by copying the `react-meteor-data` directory into a project, artificially bumping the version number (to `2.6.2_1`), and running `meteor update react-meteor-data` to verify that it picked up the later version. After running `meteor lint`, I was able to successfully pick up types for `react-meteor-data`.

Here's what I saw before:

```
evan@mathias meteor-types-test (main~1) % meteor npx tsc
[...]
imports/ui/Info.tsx:2:28 - error TS2306: File '/Users/evan/src/meteor-types-test/.meteor/local/types/packages.d.ts' is not a module.

2 import { useTracker } from 'meteor/react-meteor-data';
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
```

After taking the update, that error message is gone.