### PR TITLE
Stringify params for useSubscribe to avoid stopping the subscription when object reference changes

### DIFF
--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React hook for reactively tracking Meteor data',
-  version: '3.0.1',
+  version: '3.0.2',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages'
 })

--- a/packages/react-meteor-data/suspense/useSubscribe.ts
+++ b/packages/react-meteor-data/suspense/useSubscribe.ts
@@ -32,7 +32,7 @@ export function useSubscribeSuspense(name: string, ...params: EJSON[]) {
               isEqual(x.params, cachedSubscription.params))
         }
       }, 0)
-    }, [name, ...params])
+    }, [name, EJSON.stringify(params)])
 
   if (cachedSubscription != null) {
     if ('error' in cachedSubscription) throw cachedSubscription.error


### PR DESCRIPTION
<!--OSS-532-->

This issue was reported in our [Discord](https://discord.com/channels/1247973371040239676/1273201326318162001/1273201326318162001).

This is a video showing the issue:


https://github.com/user-attachments/assets/7490bcb1-dc34-4c39-a2a3-f84f14338156

If you check the part of the code where [we call `useSubscribe`,](https://github.com/kolyasya/meteor-sub-issue/blob/main/imports/ui/Info.jsx#L47), the params remain the same.

However, the cleanup of the `useEffect` is still triggered because we change the object reference after unmounting the page.

To solve this, we're now stringifying the params. This could cause an issue in different scenarios if the object is too big, but in this case, we are stringifying the parameters for a subscription, so it's unlikely this object will cause any issue.

Here is the result after this change:

https://github.com/user-attachments/assets/9130e02b-85b8-474b-9863-1a24bc2138bd

![image](https://github.com/user-attachments/assets/a8b1cd6d-5fc1-4b4f-86b0-3b4ca0b43cb4)

So everything now works as expected.

PS: My example is slightly different from the one done by the issue reporter. In my example, I changed the parameter in the URL to validate if the subscription with the older parameter would be dropped.

