### PR TITLE
Fix useSubscribe suspense does not work at SSR

### DIFF
--- a/packages/react-meteor-data/suspense/useSubscribe.ts
+++ b/packages/react-meteor-data/suspense/useSubscribe.ts
@@ -15,7 +15,7 @@ interface Entry {
   error?: unknown
 }
 
-export function useSubscribeSuspense(name: string, ...params: EJSON[]) {
+const useSubscribeSuspenseClient = (name: string, ...params: EJSON[]) => {
   const cachedSubscription =
     cachedSubscriptions.find(x => x.name === name && isEqual(x.params, params))
 
@@ -63,5 +63,11 @@ export function useSubscribeSuspense(name: string, ...params: EJSON[]) {
 
   throw subscription.promise
 }
+
+const useSubscribeSuspenseServer = (name?: string, ...args: any[]) => undefined;
+
+export const useSubscribeSuspense = Meteor.isServer
+? useSubscribeSuspenseServer
+: useSubscribeSuspenseClient
 
 export const useSubscribe = useSubscribeSuspense


### PR DESCRIPTION
The useSubscribe suspense throws an error when run in the server environment, the code is similar to a normal useSubscribe and is intended to run only on the client.

```ts
const useSubscribeSuspenseServer = (name?: string, ...args: any[]) => undefined;

export const useSubscribeSuspense = Meteor.isServer
? useSubscribeSuspenseServer
: useSubscribeSuspenseClient
```