### PR TITLE
Concurrency issue with use find client

### DIFF
--- a/packages/react-meteor-data/useFind.tests.js
+++ b/packages/react-meteor-data/useFind.tests.js
@@ -107,6 +107,50 @@ if (Meteor.isClient) {
     completed()
   })
 
+  Tinytest.addAsync(
+    'useFind - Immediate update before effect registration (race condition test)',
+    async function (test, completed) {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const TestDocs = new Mongo.Collection(null);
+      // Insert a single document.
+      TestDocs.insert({ id: 1, val: 'initial' });
+
+      const Test = () => {
+        const docs = useFind(() => TestDocs.find(), []);
+        return (
+          <div data-testid="doc-value">
+            {docs && docs[0] && docs[0].val}
+          </div>
+        );
+      };
+
+      // Render the component.
+      ReactDOM.render(<Test />, container);
+
+      // Immediately update the document (this should occur
+      // after the synchronous fetch in the old code but before the effect attaches).
+      TestDocs.update({ id: 1 }, { $set: { val: 'updated' } });
+
+      // Wait until the rendered output reflects the update.
+      await waitFor(() => {
+        const node = container.querySelector('[data-testid="doc-value"]');
+        if (!node || !node.textContent.includes('updated')) {
+          throw new Error('Updated value not rendered yet');
+        }
+      }, { container, timeout: 500 });
+
+      test.ok(
+        container.innerHTML.includes('updated'),
+        'Document should display updated value; the old code would fail to capture this update.'
+      );
+
+      document.body.removeChild(container);
+      completed();
+    }
+  );
+
 } else {
 
 }


### PR DESCRIPTION
Possible fix for https://github.com/meteor/react-packages/issues/418

I created a new test that failed for the current `useFind` and passed for the new one

I basically removed the `useRef` and move the Initial Fetch into the Effect, this broke the **Verify reference stability between rerenders** test so I needed to update the `refresh` action on `useFindReducer` to compare the values properly (I feel that there is room from improvement on this part).