### PR TITLE
UseFind should work like other hooks

### DIFF
--- a/packages/react-meteor-data/useFind.ts
+++ b/packages/react-meteor-data/useFind.ts
@@ -71,7 +71,7 @@ const fetchData = <T>(cursor: Mongo.Cursor<T>) => {
   return data
 }
 
-const useFindClient = <T = any>(factory: () => (Mongo.Cursor<T> | undefined | null), deps: DependencyList = []) => {
+const useFindClient = <T = any>(factory: () => (Mongo.Cursor<T> | undefined | null), deps: DependencyList) => {
   const cursor = useMemo(() => {
     // To avoid creating side effects in render, opt out
     // of Tracker integration altogether.


### PR DESCRIPTION
useFind default behavior is to have a void array as deps. This is confusing and leading to bugs hard to find.

useFind should work like useMemo, useEffect and usedTracker, having an undefined deps by default