### PR TITLE
Release 4.0.0-beta.0

### DIFF
--- a/packages/react-meteor-data/CHANGELOG.md
+++ b/packages/react-meteor-data/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v4.0.0-beta.0, xxx
+*  Breaking change: useFind describes no deps by default [#431](https://github.com/meteor/react-packages/pull/431)
+*  Fix concurrency issue with useFind [PR#419](https://github.com/meteor/react-packages/pull/419)
+*  Improve `useFind` and `useSubscribe` React suspense hooks [PR#420](https://github.com/meteor/react-packages/pull/429), [#430](https://github.com/meteor/react-packages/pull/430) and [#441](https://github.com/meteor/react-packages/pull/441)
+
 ## v3.0.3, 2024-12-30
 *  Add `useSubscribeSuspenseServer` hook to be used in SSR.
 

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React hook for reactively tracking Meteor data',
-  version: '3.0.5-beta.0',
+  version: '4.0.0-beta.0',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages'
 })


### PR DESCRIPTION
This PR updates the changelog, bump the 4.0.0-beta.0 version and release a new beta.

Since we introduced a breaking change the new version for this package will be the major 4.0.0.