### PR TITLE
react-meteor-data: restore TS support via zodern:types

### DIFF
--- a/packages/react-meteor-data/index.ts
+++ b/packages/react-meteor-data/index.ts
@@ -9,6 +9,6 @@ if (Meteor.isDevelopment) {
 }
 
 export { useTracker } from './useTracker';
-export { withTracker } from './withTracker.tsx';
+export { withTracker } from './withTracker';
 export { useFind } from './useFind';
 export { useSubscribe } from './useSubscribe';

--- a/packages/react-meteor-data/package-types.json
+++ b/packages/react-meteor-data/package-types.json
@@ -1,0 +1,3 @@
+{
+  "typesEntry": "index.ts"
+}

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -17,10 +17,9 @@ Package.onUse((api) => {
   api.use('tracker')
   api.use('ecmascript')
   api.use('typescript')
-  api.addAssets('react-meteor-data.d.ts', 'server')
-  api.addAssets('suspense/react-meteor-data.d.ts', 'server')
+  api.use('zodern:types', 'server')
 
-  api.mainModule('index.js', ['client', 'server'], { lazy: true })
+  api.mainModule('index.ts', ['client', 'server'], { lazy: true })
 })
 
 Package.onTest((api) => {


### PR DESCRIPTION
Fixes #432 

Wasn't sure what the strategy is for this repo as there is no dev or stable branch, so I just worked off of the master branch version (Meteor Package version 3.0.5-beta.0).

According to https://packosphere.com/meteor/react-meteor-data the latest stable version of the package is 3.0.3. Would be great to get this merged into 3.0.4 stable, unless a 3.0.5 is coming out soon.