### PR TITLE
refactor: replace lodash with fast-equals

### DIFF
--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -9,7 +9,7 @@ Package.describe({
 })
 
 Npm.depends({
-  'lodash.isequal': '4.5.0'
+  'fast-equals': '5.2.2'
 })
 
 Package.onUse((api) => {

--- a/packages/react-meteor-data/suspense/useTracker.ts
+++ b/packages/react-meteor-data/suspense/useTracker.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal'
+import { strictDeepEqual } from 'fast-equals'
 import { Tracker } from 'meteor/tracker'
 import { type EJSON } from 'meteor/ejson'
 import { type DependencyList, useEffect, useMemo, useReducer, useRef } from 'react'
@@ -55,7 +55,7 @@ function resolveAsync<T>(key: string, promise: Promise<T> | null, deps: Dependen
   useEffect(() =>
     () => {
       setTimeout(() => {
-        if (cached !== undefined && isEqual(cached.deps, deps)) cacheMap.delete(key)
+        if (cached !== undefined && strictDeepEqual(cached.deps, deps)) cacheMap.delete(key)
       }, 0)
     }, [cached, key, ...deps])
 


### PR DESCRIPTION
Hey,
I would like to propose to replace `lodash.isequal` with fast-equals `strictDeepEqual`. 
I was not entirely sure if [deepEqual](https://www.npmjs.com/package/fast-equals#available-methods) or [strictDeepEqual](https://www.npmjs.com/package/fast-equals#strictdeepequal) would be the correct replacement.

I want to replace it because vite has issues with the import of `lodash.isequal` and the package is already deprecated.

