### PR TITLE
Update React and ReactDOM version range to 19

### DIFF
--- a/packages/react-template-helper/react-template-helper.js
+++ b/packages/react-template-helper/react-template-helper.js
@@ -1,7 +1,7 @@
 import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 checkNpmVersions({
-  'react': '15.3 - 18',
-  'react-dom': '15.3 - 18'
+  'react': '15.3 - 19',
+  'react-dom': '15.3 - 19'
 }, 'react-template-helper');
 
 const React = require('react');


### PR DESCRIPTION
Removes the browser console warning about not having a compatible version of React when using the latest 19.x npm versions of `react` and `react-dom`.