### PR TITLE
fix(useTrackerSuspense): fix performance issues when multiple useTracker with suspense exist and rebuild test cases. Closes #454

### DIFF
--- a/packages/react-meteor-data/suspense/useTracker.ts
+++ b/packages/react-meteor-data/suspense/useTracker.ts
@@ -44,12 +44,6 @@ export type IReactiveFn<T> = (c?: Tracker.Computation) => Promise<T>
 
 export type ISkipUpdate<T> = <T>(prev: T, next: T) => boolean
 
-interface TrackerRefs {
-  computation?: Tracker.Computation
-  isMounted: boolean
-  trackerData: any
-}
-
 function resolveAsync<T>(key: string, promise: Promise<T> | null, deps: DependencyList = []): typeof promise extends null ? null : T {
   const cached = cacheMap.get(key)
   useEffect(() =>
@@ -62,14 +56,13 @@ function resolveAsync<T>(key: string, promise: Promise<T> | null, deps: Dependen
   if (promise === null) return null
 
   if (cached !== undefined) {
-    if ('error' in cached) throw cached.error
-    if ('result' in cached) {
-      const result = cached.result as T
+    if (Meteor.isServer && ('error' in cached || 'result' in cached)) {
       setTimeout(() => {
         cacheMap.delete(key)
       }, 0)
-      return result
     }
+    if ('error' in cached) throw cached.error
+    if ('result' in cached) return cached.result as T
     throw cached.promise
   }
 
@@ -91,19 +84,16 @@ function resolveAsync<T>(key: string, promise: Promise<T> | null, deps: Dependen
   throw entry.promise
 }
 
-export function useTrackerNoDeps<T = any>(key: string, reactiveFn: IReactiveFn<T>, skipUpdate: ISkipUpdate<T> = null): T {
-  const { current: refs } = useRef<TrackerRefs>({
+export function useTrackerSuspenseNoDeps<T = any>(key: string, reactiveFn: IReactiveFn<T>, skipUpdate: ISkipUpdate<T> = null): T {
+  const { current: refs } = useRef<{
+    isMounted: boolean
+    computation?: Tracker.Computation
+    trackerData: any
+  }>({
     isMounted: false,
     trackerData: null
   })
   const forceUpdate = useForceUpdate()
-
-  // Without deps, always dispose and recreate the computation with every render.
-  if (refs.computation != null) {
-    refs.computation.stop()
-    // @ts-expect-error This makes TS think ref.computation is "never" set
-    delete refs.computation
-  }
 
   // Use Tracker.nonreactive in case we are inside a Tracker Computation.
   // This can happen if someone calls `ReactDOM.render` inside a Computation.
@@ -111,54 +101,30 @@ export function useTrackerNoDeps<T = any>(key: string, reactiveFn: IReactiveFn<T
   // Computations, where if the outer one is invalidated or stopped,
   // it stops the inner one.
   Tracker.nonreactive(() =>
-    Tracker.autorun(async (c: Tracker.Computation) => {
-      refs.computation = c
-
-      const data: Promise<any> = Tracker.withComputation(c, async () => reactiveFn(c))
-      if (c.firstRun) {
-        // Always run the reactiveFn on firstRun
-        refs.trackerData = data
-      } else if (!skipUpdate || !skipUpdate(await refs.trackerData, await data)) {
-        // For any reactive change, forceUpdate and let the next render rebuild the computation.
-        forceUpdate()
-      }
-    }))
-
-  // To clean up side effects in render, stop the computation immediately
-  if (!refs.isMounted) {
-    Meteor.defer(() => {
-      if (!refs.isMounted && (refs.computation != null)) {
+    Tracker.autorun(async (comp: Tracker.Computation) => {
+      if (refs.computation) {
         refs.computation.stop()
         delete refs.computation
       }
-    })
-  }
+
+      refs.computation = comp
+
+      const data: Promise<any> = Tracker.withComputation(comp, async () => reactiveFn(comp))
+
+      if (comp.firstRun) {
+        // Always run the reactiveFn on firstRun
+        refs.trackerData = data
+      } else if (!skipUpdate || !skipUpdate(await refs.trackerData, await data)) {
+        cacheMap.delete(key)
+
+        // For any reactive change, forceUpdate and let the next render rebuild the computation.
+        refs.isMounted && forceUpdate()
+      }
+  }))
 
   useEffect(() => {
     // Let subsequent renders know we are mounted (render is committed).
     refs.isMounted = true
-
-    // In some cases, the useEffect hook will run before Meteor.defer, such as
-    // when React.lazy is used. In those cases, we might as well leave the
-    // computation alone!
-    if (refs.computation == null) {
-      // Render is committed, but we no longer have a computation. Invoke
-      // forceUpdate and let the next render recreate the computation.
-      if (!skipUpdate) {
-        forceUpdate()
-      } else {
-        Tracker.nonreactive(() =>
-          Tracker.autorun(async (c: Tracker.Computation) => {
-            const data = Tracker.withComputation(c, async () => reactiveFn(c))
-
-            refs.computation = c
-            if (!skipUpdate(await refs.trackerData, await data)) {
-              // For any reactive change, forceUpdate and let the next render rebuild the computation.
-              forceUpdate()
-            }
-          }))
-      }
-    }
 
     // stop the computation on unmount
     return () => {
@@ -171,16 +137,20 @@ export function useTrackerNoDeps<T = any>(key: string, reactiveFn: IReactiveFn<T
   return resolveAsync(key, refs.trackerData)
 }
 
-export const useTrackerWithDeps =
-  <T = any>(key: string, reactiveFn: IReactiveFn<T>, deps: DependencyList, skipUpdate: ISkipUpdate<T> = null): T => {
+export const useTrackerSuspenseWithDeps =
+  <T = any>(key: string, reactiveFn: IReactiveFn<T>, deps: DependencyList, skipUpdate?: ISkipUpdate<T> = null): T => {
     const forceUpdate = useForceUpdate()
 
     const { current: refs } = useRef<{
       reactiveFn: IReactiveFn<T>
-      data?: Promise<T>
-      comp?: Tracker.Computation
-      isMounted?: boolean
-    }>({ reactiveFn })
+      isMounted: boolean
+      trackerData?: Promise<T>
+      computation?: Tracker.Computation
+    }>({ 
+      reactiveFn, 
+      isMounted: false,
+      trackerData: null
+    })
 
     // keep reactiveFn ref fresh
     refs.reactiveFn = reactiveFn
@@ -188,88 +158,66 @@ export const useTrackerWithDeps =
     useMemo(() => {
       // To jive with the lifecycle interplay between Tracker/Subscribe, run the
       // reactive function in a computation, then stop it, to force flush cycle.
-      const comp = Tracker.nonreactive(
-        () => Tracker.autorun(async (c: Tracker.Computation) => {
-          const data = Tracker.withComputation(c, async () => refs.reactiveFn(c))
-          if (c.firstRun) {
-            refs.data = data
-          } else if (!skipUpdate || !skipUpdate(await refs.data, await data)) {
-            refs.data = data
-            forceUpdate()
+      Tracker.nonreactive(
+        () => Tracker.autorun(async (comp: Tracker.Computation) => {
+          if (refs.computation) {
+            refs.computation.stop()
+            delete refs.computation
+          }
+
+          refs.computation = comp
+
+          const data = Tracker.withComputation(comp, async () => refs.reactiveFn(comp))
+
+          if (comp.firstRun) {
+            refs.trackerData = data
+          } else if (!skipUpdate || !skipUpdate(await refs.trackerData, await data)) {
+            cacheMap.delete(key)
+            
+            refs.isMounted && forceUpdate()
           }
         })
       )
-
-      // Stop the computation immediately to avoid creating side effects in render.
-      // refers to this issues:
-      // https://github.com/meteor/react-packages/issues/382
-      // https://github.com/meteor/react-packages/issues/381
-      if (refs.comp != null) refs.comp.stop()
-
-      // In some cases, the useEffect hook will run before Meteor.defer, such as
-      // when React.lazy is used. This will allow it to be stopped earlier in
-      // useEffect if needed.
-      refs.comp = comp
-      // To avoid creating side effects in render, stop the computation immediately
-      Meteor.defer(() => {
-        if (!refs.isMounted && (refs.comp != null)) {
-          refs.comp.stop()
-          delete refs.comp
-        }
-      })
     }, deps)
 
     useEffect(() => {
       // Let subsequent renders know we are mounted (render is committed).
       refs.isMounted = true
 
-      if (refs.comp == null) {
-        refs.comp = Tracker.nonreactive(
-          () => Tracker.autorun(async (c) => {
-            const data: Promise<T> = Tracker.withComputation(c, async () => refs.reactiveFn())
-            if (!skipUpdate || !skipUpdate(await refs.data, await data)) {
-              refs.data = data
-              forceUpdate()
-            }
-          })
-        )
-      }
-
       return () => {
-        // @ts-expect-error
-        refs.comp.stop()
-        delete refs.comp
+        refs.computation.stop()
+        delete refs.computation
         refs.isMounted = false
       }
     }, deps)
 
-    return resolveAsync(key, refs.data as Promise<T>, deps)
+    return resolveAsync(key, refs.trackerData, deps)
   }
 
-function useTrackerClient<T = any>(key: string, reactiveFn: IReactiveFn<T>, skipUpdate?: ISkipUpdate<T>): T
-function useTrackerClient<T = any>(key: string, reactiveFn: IReactiveFn<T>, deps?: DependencyList, skipUpdate?: ISkipUpdate<T>): T
-function useTrackerClient<T = any>(key: string, reactiveFn: IReactiveFn<T>, deps: DependencyList | ISkipUpdate<T> = null, skipUpdate: ISkipUpdate<T> = null): T {
+export function useTrackerSuspenseClient<T = any>(key: string, reactiveFn: IReactiveFn<T>, skipUpdate?: ISkipUpdate<T>): T
+export function useTrackerSuspenseClient<T = any>(key: string, reactiveFn: IReactiveFn<T>, deps?: DependencyList, skipUpdate?: ISkipUpdate<T>): T
+export function useTrackerSuspenseClient<T = any>(key: string, reactiveFn: IReactiveFn<T>, deps: DependencyList | ISkipUpdate<T> = null, skipUpdate: ISkipUpdate<T> = null): T {
   if (deps === null || deps === undefined || !Array.isArray(deps)) {
     if (typeof deps === 'function') {
       skipUpdate = deps
     }
-    return useTrackerNoDeps(key, reactiveFn, skipUpdate)
+    return useTrackerSuspenseNoDeps(key, reactiveFn, skipUpdate)
   } else {
-    return useTrackerWithDeps(key, reactiveFn, deps, skipUpdate)
+    return useTrackerSuspenseWithDeps(key, reactiveFn, deps, skipUpdate)
   }
 }
 
-const useTrackerServer: typeof useTrackerClient = (key, reactiveFn) => {
+export const useTrackerSuspenseServer: typeof useTrackerSuspenseClient = (key, reactiveFn) => {
   return resolveAsync(key, Tracker.nonreactive(reactiveFn))
 }
 
 // When rendering on the server, we don't want to use the Tracker.
 // We only do the first rendering on the server so we can get the data right away
-const _useTracker = Meteor.isServer
-  ? useTrackerServer
-  : useTrackerClient
+export const useTracker = Meteor.isServer
+  ? useTrackerSuspenseServer
+  : useTrackerSuspenseClient
 
-function useTrackerDev(key: string, reactiveFn, deps: DependencyList | null = null, skipUpdate = null) {
+function useTrackerDev(key: string, reactiveFn: any, deps: DependencyList | null = null, skipUpdate = null) {
   function warn(expects: string, pos: string, arg: string, type: string) {
     console.warn(
       `Warning: useTracker expected a ${expects} in it\'s ${pos} argument ` +
@@ -293,11 +241,11 @@ function useTrackerDev(key: string, reactiveFn, deps: DependencyList | null = nu
     }
   }
 
-  const data = _useTracker(key, reactiveFn, deps, skipUpdate)
+  const data = useTracker(key, reactiveFn, deps, skipUpdate)
   checkCursor(data)
   return data
 }
 
-export const useTracker = Meteor.isDevelopment
-  ? useTrackerDev as typeof useTrackerClient
-  : _useTracker
+export default Meteor.isDevelopment
+  ? useTrackerDev
+  : useTracker

--- a/packages/react-meteor-data/tests.js
+++ b/packages/react-meteor-data/tests.js
@@ -1,5 +1,6 @@
 import './useTracker.tests.js'
 import './withTracker.tests.js'
 import './useFind.tests.js'
+import './suspense/useTracker.tests.js'
 import './suspense/useSubscribe.tests.js'
 import './suspense/useFind.tests.js'


### PR DESCRIPTION
## Summary
This PR primarily addresses the performance issue described in #454. 

## Problem Analysis
In the original implementation, the cache was immediately cleared every time a Promise was thrown and resolved. This caused components to re-throw Promises upon updates, leading to an exponential growth in Promise throwing when multiple `useTracker` hooks were used concurrently.

## Solution
The key insight is that immediate cache clearance is only necessary on the Server-Side. This optimization significantly reduces unnecessary Promise re-throws and improves performance in components with multiple `useTracker` instances.

## Additional Changes
- Rebuilt majority of the test cases for `useTracker` with Suspense functionality
- Added comprehensive performance testing for multiple subscription scenarios