### PR TITLE
fix(useTrackerSuspense): fix unmount error in StrictMode (dev only)

### DIFF
--- a/packages/react-meteor-data/suspense/useTracker.tests.js
+++ b/packages/react-meteor-data/suspense/useTracker.tests.js
@@ -428,3 +428,29 @@ Meteor.isClient &&
       );
     }
   );
+
+Meteor.isClient &&
+  runForVariants(
+    'suspense/useTracker - component unmount in Strict Mode',
+    async function (test, useTrackerFn) {
+      const { simpleFetch } = setupTest();
+
+      const Test = () => {
+        useTrackerFn('TestDocs', simpleFetch);
+
+        return null;
+      };
+
+      const { queryByText, findByText, unmount } = render(<Test />, {
+        container: document.createElement('container'),
+        wrapper: TestSuspense,
+        reactStrictMode: true,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      unmount();
+
+      test.isTrue(true, 'should handle unmount correctly in Strict Mode');
+    }
+  );

--- a/packages/react-meteor-data/suspense/useTracker.ts
+++ b/packages/react-meteor-data/suspense/useTracker.ts
@@ -131,8 +131,11 @@ export function useTrackerSuspenseNoDeps<T = any>(key: string, reactiveFn: IReac
 
     // stop the computation on unmount
     return () => {
-      refs.computation?.stop()
-      delete refs.computation
+      if (refs.computation) {
+        refs.computation.stop()
+        delete refs.computation
+      }
+
       refs.isMounted = false
     }
   }, [])
@@ -192,8 +195,11 @@ export const useTrackerSuspenseWithDeps =
       refs.isMounted = true
 
       return () => {
-        refs.computation.stop()
-        delete refs.computation
+        if (refs.computation) {
+          refs.computation.stop()
+          delete refs.computation
+        }
+
         refs.isMounted = false
       }
     }, deps)


### PR DESCRIPTION
This commit addresses an issue where component unmounting in React StrictMode was causing errors to be thrown. The problem was isolated to development environments only, as StrictMode additional checks are not performed in production. The fix ensures proper cleanup during unmount lifecycle without triggering these development-only warnings.