### PR TITLE
feat: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: Report a bug
+title: "[BUG]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: Describe the bug clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: ✨ Feature Request
+description: Suggest a new feature
+title: "[FEATURE]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: Describe the feature you want.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should it work?
+    validations:
+      required: true


### PR DESCRIPTION
Fixed #463 


.github/
└── ISSUE_TEMPLATE/
    ├── bug_report.yml        # Bug reporting template
    └── feature_request.yml  # Feature request template


## 🎯 Purpose
- Provide a structured way to report bugs
- Make feature requests clear and consistent
- Improve contributor experience

## 🔗 Related
No related issue (maintenance / repository improvement)

## ✅ Checklist
- [x] Added bug report issue template
- [x] Added feature request issue template
- [x] Followed GitHub Issue Forms (YAML)
