### PR TITLE
react-meteor-data: support typescript@6 (v4.1.0-beta.0)

### DIFF
--- a/packages/react-meteor-data/CHANGELOG.md
+++ b/packages/react-meteor-data/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v4.1.0-beta.0, 2026-07-20
+*  Add compatibility with the `typescript@6.x` Meteor package so the package can
+   be used on Meteor releases built against TypeScript 6 (see
+   [meteor/meteor#14560](https://github.com/meteor/meteor/pull/14560)). The
+   supported `typescript` range is now set explicitly in `package.js` because
+   TypeScript 6 is not yet part of a published release and can't be pulled in
+   through `api.versionsFrom`.
+
 ## v4.0.1, 2026-1-30
 
 *  Fix performance issues with suspense trackers for stability and performance. [PR#455](https://github.com/meteor/react-packages/pull/455) and [PR#458](https://github.com/meteor/react-packages/pull/458)

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React hook for reactively tracking Meteor data',
-  version: '4.0.1',
+  version: '4.1.0-beta.0',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages'
 })
@@ -12,18 +12,28 @@ Npm.depends({
   'fast-equals': '5.2.2'
 })
 
+// Supported versions of the `typescript` Meteor package. This is set
+// explicitly instead of being derived from `api.versionsFrom` because
+// TypeScript 6.x is not yet part of any published Meteor release, so it can't
+// be pulled in through `versionsFrom`. The 3.7.0/4.1.2/4.3.2/5.4.3 entries
+// mirror the typescript versions shipped by the releases listed in
+// `versionsFrom` below; 6.0.0 adds compatibility with releases on TypeScript 6
+// (see meteor/meteor#14560).
+const TYPESCRIPT_VERSIONS = 'typescript@3.7.0 || 4.1.2 || 4.3.2 || 5.4.3 || 6.0.0'
+
 Package.onUse((api) => {
   api.versionsFrom(['1.8.2', '1.12', '2.0', '2.3', '3.0'])
   api.use('tracker')
   api.use('ecmascript')
-  api.use('typescript')
+  api.use(TYPESCRIPT_VERSIONS)
   api.use('zodern:types@1.0.13', 'server')
 
   api.mainModule('index.ts', ['client', 'server'], { lazy: true })
 })
 
 Package.onTest((api) => {
-  api.use(['ecmascript', 'typescript', 'reactive-dict', 'reactive-var', 'tracker', 'tinytest', 'underscore', 'mongo'])
+  api.use(['ecmascript', 'reactive-dict', 'reactive-var', 'tracker', 'tinytest', 'underscore', 'mongo'])
+  api.use(TYPESCRIPT_VERSIONS)
   api.use('test-helpers')
   api.use('react-meteor-data')
   api.use('jquery@3.0.0', 'client');


### PR DESCRIPTION
## Problem

The published `react-meteor-data` derives its `typescript` dependency constraint from `api.versionsFrom(['1.8.2', '1.12', '2.0', '2.3', '3.0'])`, which resolves to:

```
typescript@3.7.0 || 4.1.2 || 4.1.2 || 4.3.2 || 5.4.3
```

Every entry is capped below `6.0.0` (Meteor's `@X.Y.Z` means `>=X.Y.Z <(X+1).0.0`). Meteor is now moving to TypeScript 6 in [meteor/meteor#14560](https://github.com/meteor/meteor/pull/14560), which bumps the `typescript` package to `6.0.3`. On that release, resolving `react-meteor-data` fails:

```
error: Conflict: Constraint typescript@3.7.0 || 4.1.2 || 4.1.2 || 4.3.2 || 5.4.3
is not satisfied by typescript 6.0.3.
* typescript@6.0.3 <- top level
* typescript@3.7.0 || 4.1.2 || 4.1.2 || 4.3.2 || 5.4.3 <- react-meteor-data 4.0.1
```

This is what breaks the `ecmascript-regression` self-test (group 7) on that PR.

## Fix

TypeScript 6 is not part of any published Meteor release yet, so it can't be pulled in through `api.versionsFrom`. Instead, set the supported `typescript` range explicitly and add `6.0.0`, keeping the existing lower versions for backwards compatibility:

```js
const TYPESCRIPT_VERSIONS = 'typescript@3.7.0 || 4.1.2 || 4.3.2 || 5.4.3 || 6.0.0'
```

Applied to both `onUse` and `onTest`. Version bumped to **`4.1.0-beta.0`** (beta).

> Note: once a Meteor release shipping TypeScript 6 is published, this can move back to a plain `api.use('typescript')` by adding that release to `versionsFrom`.

## Testing

Verified locally against a Meteor checkout with the `typescript` package bumped to `6.0.3`:

- **Before** (published `react-meteor-data@4.0.1`): fails with the conflict above.
- **After** (`4.1.0-beta.0` from this branch): resolves cleanly —

```
react-meteor-data  4.1.0-beta.0+  React hook for reactively tracking Meteor data
typescript         6.0.3+         Compiler plugin that compiles TypeScript and ECMAScript...
```