### PR TITLE
react-meteor-data: support TypeScript 7

### DIFF
--- a/packages/react-meteor-data/CHANGELOG.md
+++ b/packages/react-meteor-data/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v4.1.0-beta.1, 2026-08-19
+* Add compatibility with the `typescript@7.x` Meteor package so the package can
+  be used on Meteor releases built against TypeScript 7 (see
+  [meteor/meteor#14319](https://github.com/meteor/meteor/pull/14319)).
+
 ## v4.1.0-beta.0, 2026-07-20
 *  Add compatibility with the `typescript@6.x` Meteor package so the package can
    be used on Meteor releases built against TypeScript 6 (see

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React hook for reactively tracking Meteor data',
-  version: '4.1.0-beta.0',
+  version: '4.1.0-beta.1',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages'
 })
@@ -18,8 +18,9 @@ Npm.depends({
 // be pulled in through `versionsFrom`. The 3.7.0/4.1.2/4.3.2/5.4.3 entries
 // mirror the typescript versions shipped by the releases listed in
 // `versionsFrom` below; 6.0.0 adds compatibility with releases on TypeScript 6
-// (see meteor/meteor#14560).
-const TYPESCRIPT_VERSIONS = 'typescript@3.7.0 || 4.1.2 || 4.3.2 || 5.4.3 || 6.0.0'
+// (see meteor/meteor#14560). The 7.0.2 entry supports Meteor releases built
+// against TypeScript 7 (see meteor/meteor#14319).
+const TYPESCRIPT_VERSIONS = 'typescript@3.7.0 || 4.1.2 || 4.3.2 || 5.4.3 || 6.0.0 || 7.0.2'
 
 Package.onUse((api) => {
   api.versionsFrom(['1.8.2', '1.12', '2.0', '2.3', '3.0'])


### PR DESCRIPTION
## Summary

Adds `typescript@7.0.2` to the explicit supported constraint used by `react-meteor-data`, and advances the pending beta version to `4.1.0-beta.1`.

## Why

Meteor’s TypeScript 7 work resolves `typescript@7.0.2`. Without this constraint, apps that use `react-meteor-data` cannot select TypeScript 7 and the dependency solver fails.

This is stacked on #490, which adds TypeScript 6 support. It also supports the Meteor TypeScript 7 work in meteor/meteor#14319.

## Validation

- Reproduced the dependency-solver conflict with TypeScript 7 before the change.
- Confirmed a temporary Meteor app can select `typescript@7.0.2` with the updated local package.
- Ran `meteor npm run test:ci` in `tests/react-meteor-data-harness`.

No package has been published as part of this PR.