### PR TITLE
react-meteor-data: support TypeScript 7

### DIFF
--- a/packages/react-meteor-data/CHANGELOG.md
+++ b/packages/react-meteor-data/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v4.1.0-beta.0, 2026-08-19
+* Add compatibility with the `typescript@7.x` Meteor package so the package can
+  be used on Meteor releases built against TypeScript 7 (see
+  [meteor/meteor#14319](https://github.com/meteor/meteor/pull/14319)). The
+  supported `typescript` range is set explicitly in `package.js` because
+  TypeScript 7 is not yet part of a published release and can't be pulled in
+  through `api.versionsFrom`.
+
 ## v4.0.1, 2026-1-30
 
 *  Fix performance issues with suspense trackers for stability and performance. [PR#455](https://github.com/meteor/react-packages/pull/455) and [PR#458](https://github.com/meteor/react-packages/pull/458)

--- a/packages/react-meteor-data/CHANGELOG.md
+++ b/packages/react-meteor-data/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v4.1.0-beta.0, 2026-08-19
+## v4.1.0-beta.1, 2026-08-19
 * Add compatibility with the `typescript@7.x` Meteor package so the package can
   be used on Meteor releases built against TypeScript 7 (see
   [meteor/meteor#14319](https://github.com/meteor/meteor/pull/14319)). The

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React hook for reactively tracking Meteor data',
-  version: '4.0.1',
+  version: '4.1.0-beta.0',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages'
 })
@@ -12,18 +12,28 @@ Npm.depends({
   'fast-equals': '5.2.2'
 })
 
+// Supported versions of the `typescript` Meteor package. This is set
+// explicitly instead of being derived from `api.versionsFrom` because
+// TypeScript 7.x is not yet part of any published Meteor release, so it can't
+// be pulled in through `versionsFrom`. The 3.7.0/4.1.2/4.3.2/5.4.3 entries
+// mirror the typescript versions shipped by the releases listed in
+// `versionsFrom` below; 7.0.2 adds compatibility with releases on TypeScript 7
+// (see meteor/meteor#14319).
+const TYPESCRIPT_VERSIONS = 'typescript@3.7.0 || 4.1.2 || 4.3.2 || 5.4.3 || 7.0.2'
+
 Package.onUse((api) => {
   api.versionsFrom(['1.8.2', '1.12', '2.0', '2.3', '3.0'])
   api.use('tracker')
   api.use('ecmascript')
-  api.use('typescript')
+  api.use(TYPESCRIPT_VERSIONS)
   api.use('zodern:types@1.0.13', 'server')
 
   api.mainModule('index.ts', ['client', 'server'], { lazy: true })
 })
 
 Package.onTest((api) => {
-  api.use(['ecmascript', 'typescript', 'reactive-dict', 'reactive-var', 'tracker', 'tinytest', 'underscore', 'mongo'])
+  api.use(['ecmascript', 'reactive-dict', 'reactive-var', 'tracker', 'tinytest', 'underscore', 'mongo'])
+  api.use(TYPESCRIPT_VERSIONS)
   api.use('test-helpers')
   api.use('react-meteor-data')
   api.use('jquery@3.0.0', 'client');

--- a/packages/react-meteor-data/package.js
+++ b/packages/react-meteor-data/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: 'react-meteor-data',
   summary: 'React hook for reactively tracking Meteor data',
-  version: '4.1.0-beta.0',
+  version: '4.1.0-beta.1',
   documentation: 'README.md',
   git: 'https://github.com/meteor/react-packages'
 })


### PR DESCRIPTION
## Summary

Adds `typescript@7.0.2` to the explicit supported constraint used by `react-meteor-data` and releases the corresponding package version as `4.1.0-beta.1`.

## Why

The constraint inferred through `api.versionsFrom` only supports TypeScript through 5.4.3. Apps that use `react-meteor-data` therefore cannot select TypeScript 7.

This PR makes the supported TypeScript versions explicit and adds TypeScript 7 support. It does not add a TypeScript 6-specific constraint. It supports meteor/meteor#14319.

Replaces #490 and #496.

## Validation

- Reproduced the dependency-solver conflict with `typescript@7.0.2` before the change.
- Confirmed a temporary Meteor app can select `typescript@7.0.2` with the updated local package.
- Ran `meteor npm run test:ci` in `tests/react-meteor-data-harness` (56 passed).

`react-meteor-data@4.1.0-beta.1` has been published.